### PR TITLE
NP-2801Wrappers for final ElasticSearch classes

### DIFF
--- a/batch-index/src/test/java/no/unit/nva/search/ImportToSearchIndexHandlerTest.java
+++ b/batch-index/src/test/java/no/unit/nva/search/ImportToSearchIndexHandlerTest.java
@@ -15,7 +15,6 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
-import no.unit.nva.dataimport.S3IonReader;
 import no.unit.nva.search.exception.SearchException;
 import nva.commons.core.Environment;
 import nva.commons.core.ioutils.IoUtils;

--- a/search-commons/src/main/java/no/unit/nva/search/ElasticSearchHighLevelRestClient.java
+++ b/search-commons/src/main/java/no/unit/nva/search/ElasticSearchHighLevelRestClient.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -35,9 +36,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class ElasticSearchHighLevelRestClient {
-
 
     public static final String ELASTICSEARCH_ENDPOINT_INDEX_KEY = "ELASTICSEARCH_ENDPOINT_INDEX";
     public static final String ELASTICSEARCH_ENDPOINT_ADDRESS_KEY = "ELASTICSEARCH_ENDPOINT_ADDRESS";
@@ -49,7 +48,7 @@ public class ElasticSearchHighLevelRestClient {
     public static final String TOOK_JSON_POINTER = "/took";
     public static final String HITS_JSON_POINTER = "/hits/hits";
     public static final String DOCUMENT_WITH_ID_WAS_NOT_FOUND_IN_ELASTICSEARCH
-            = "Document with id={} was not found in elasticsearch";
+        = "Document with id={} was not found in elasticsearch";
     public static final URI DEFAULT_SEARCH_CONTEXT = URI.create("https://api.nva.unit.no/resources/search");
     private static final Logger logger = LoggerFactory.getLogger(ElasticSearchHighLevelRestClient.class);
     private static final String SERVICE_NAME = "es";
@@ -58,7 +57,7 @@ public class ElasticSearchHighLevelRestClient {
     private final String elasticSearchEndpointAddress;
     private final String elasticSearchRegion;
     private final String elasticSearchEndpointIndex;
-    private final RestHighLevelClient elasticSearchClient;
+    private final RestHighLevelClientWrapper elasticSearchClient;
 
     /**
      * Creates a new ElasticSearchRestClient.
@@ -70,18 +69,18 @@ public class ElasticSearchHighLevelRestClient {
         elasticSearchEndpointIndex = environment.readEnv(ELASTICSEARCH_ENDPOINT_INDEX_KEY);
         elasticSearchRegion = environment.readEnv(ELASTICSEARCH_ENDPOINT_REGION_KEY);
         elasticSearchClient = createElasticsearchClientWithInterceptor(
-                elasticSearchRegion,
-                elasticSearchEndpointAddress);
+            elasticSearchRegion,
+            elasticSearchEndpointAddress);
         logger.info(INITIAL_LOG_MESSAGE, elasticSearchEndpointAddress, elasticSearchEndpointIndex);
     }
 
     /**
      * Creates a new ElasticSearchRestClient.
      *
-     * @param environment Environment with properties
+     * @param environment         Environment with properties
      * @param elasticSearchClient client to use for access to ElasticSearch
      */
-    public ElasticSearchHighLevelRestClient(Environment environment, RestHighLevelClient elasticSearchClient) {
+    public ElasticSearchHighLevelRestClient(Environment environment, RestHighLevelClientWrapper elasticSearchClient) {
         elasticSearchEndpointAddress = environment.readEnv(ELASTICSEARCH_ENDPOINT_ADDRESS_KEY);
         elasticSearchEndpointIndex = environment.readEnv(ELASTICSEARCH_ENDPOINT_INDEX_KEY);
         elasticSearchRegion = environment.readEnv(ELASTICSEARCH_ENDPOINT_REGION_KEY);
@@ -91,7 +90,8 @@ public class ElasticSearchHighLevelRestClient {
 
     /**
      * Searches for an term or index:term in elasticsearch index.
-     * @param term search argument
+     *
+     * @param term    search argument
      * @param results number of results
      * @throws ApiGatewayException thrown when uri is misconfigured, service i not available or interrupted
      */
@@ -110,9 +110,10 @@ public class ElasticSearchHighLevelRestClient {
 
     /**
      * Adds or insert a document to an elasticsearch index.
+     *
      * @param document the document to be inserted
      * @throws SearchException when something goes wrong
-     * */
+     */
     public void addDocumentToIndex(IndexDocument document) throws SearchException {
         try {
             doUpsert(document);
@@ -123,6 +124,7 @@ public class ElasticSearchHighLevelRestClient {
 
     /**
      * Removes an document from Elasticsearch index.
+     *
      * @param identifier og document
      * @throws SearchException when
      */
@@ -134,16 +136,19 @@ public class ElasticSearchHighLevelRestClient {
         }
     }
 
-    protected final RestHighLevelClient createElasticsearchClientWithInterceptor(String region,
-                                                                                 String elasticSearchEndpoint) {
+    protected final RestHighLevelClientWrapper createElasticsearchClientWithInterceptor(String region,
+                                                                                        String elasticSearchEndpoint) {
         AWS4Signer signer = getAws4Signer(ElasticSearchHighLevelRestClient.SERVICE_NAME, region);
         HttpRequestInterceptor interceptor =
-                new AWSRequestSigningApacheInterceptor(ElasticSearchHighLevelRestClient.SERVICE_NAME,
-                        signer,
-                        credentialsProvider);
+            new AWSRequestSigningApacheInterceptor(ElasticSearchHighLevelRestClient.SERVICE_NAME,
+                                                   signer,
+                                                   credentialsProvider);
 
-        return new RestHighLevelClient(RestClient.builder(HttpHost.create(elasticSearchEndpoint))
-                .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor)));
+        RestClientBuilder clientBuilder = RestClient
+                                              .builder(HttpHost.create(elasticSearchEndpoint))
+                                              .setHttpClientConfigCallback(
+                                                  hacb -> hacb.addInterceptorLast(interceptor));
+        return new RestHighLevelClientWrapper(clientBuilder);
     }
 
     private static int intFromNode(JsonNode jsonNode, String jsonPointer) {
@@ -161,18 +166,18 @@ public class ElasticSearchHighLevelRestClient {
                                     String orderBy,
                                     SortOrder sortOrder) throws IOException {
         return elasticSearchClient.search(getSearchRequest(term,
-                results,
-                from,
-                orderBy,
-                sortOrder), RequestOptions.DEFAULT);
+                                                           results,
+                                                           from,
+                                                           orderBy,
+                                                           sortOrder), RequestOptions.DEFAULT);
     }
 
     private SearchRequest getSearchRequest(String term, int results, int from, String orderBy, SortOrder sortOrder) {
         final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
-            .query(QueryBuilders.queryStringQuery(term))
-            .sort(orderBy, sortOrder)
-            .from(from)
-            .size(results);
+                                                      .query(QueryBuilders.queryStringQuery(term))
+                                                      .sort(orderBy, sortOrder)
+                                                      .from(from)
+                                                      .size(results);
         return new SearchRequest(elasticSearchEndpointIndex).source(sourceBuilder);
     }
 
@@ -181,16 +186,16 @@ public class ElasticSearchHighLevelRestClient {
         elasticSearchClient.index(getUpdateRequest(document), RequestOptions.DEFAULT);
     }
 
-
     private IndexRequest getUpdateRequest(IndexDocument document) {
         return new IndexRequest(elasticSearchEndpointIndex)
-                .source(document.toJsonString(), XContentType.JSON)
-                .id(document.getId().toString());
+                   .source(document.toJsonString(), XContentType.JSON)
+                   .id(document.getId().toString());
     }
 
     private void doDelete(String identifier) throws IOException {
         DeleteResponse deleteResponse = elasticSearchClient
-                .delete(new DeleteRequest(elasticSearchEndpointIndex, identifier), RequestOptions.DEFAULT);
+                                            .delete(new DeleteRequest(elasticSearchEndpointIndex, identifier),
+                                                    RequestOptions.DEFAULT);
         if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
             logger.warn(DOCUMENT_WITH_ID_WAS_NOT_FOUND_IN_ELASTICSEARCH, identifier);
         }
@@ -201,20 +206,20 @@ public class ElasticSearchHighLevelRestClient {
 
         List<JsonNode> sourceList = extractSourceList(values);
         int total = intFromNode(values, TOTAL_JSON_POINTER);
-        int took =  intFromNode(values, TOOK_JSON_POINTER);
+        int took = intFromNode(values, TOOK_JSON_POINTER);
 
         return new SearchResourcesResponse.Builder()
-                .withContext(DEFAULT_SEARCH_CONTEXT)
-                .withTook(took)
-                .withTotal(total)
-                .withHits(sourceList)
-                .build();
+                   .withContext(DEFAULT_SEARCH_CONTEXT)
+                   .withTook(took)
+                   .withTotal(total)
+                   .withHits(sourceList)
+                   .build();
     }
 
     private List<JsonNode> extractSourceList(JsonNode record) {
         return toStream(record.at(HITS_JSON_POINTER))
-                .map(this::extractSourceStripped)
-                .collect(Collectors.toList());
+                   .map(this::extractSourceStripped)
+                   .collect(Collectors.toList());
     }
 
     private JsonNode extractSourceStripped(JsonNode record) {

--- a/search-commons/src/main/java/no/unit/nva/search/ElasticSearchHighLevelRestClient.java
+++ b/search-commons/src/main/java/no/unit/nva/search/ElasticSearchHighLevelRestClient.java
@@ -28,7 +28,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;

--- a/search-commons/src/main/java/no/unit/nva/search/IndexDate.java
+++ b/search-commons/src/main/java/no/unit/nva/search/IndexDate.java
@@ -1,16 +1,14 @@
 package no.unit.nva.search;
 
+import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Objects;
 import no.unit.nva.model.PublicationDate;
 import nva.commons.core.JacocoGenerated;
-
-import java.util.Objects;
-
-import static java.util.Objects.nonNull;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class IndexDate {

--- a/search-commons/src/main/java/no/unit/nva/search/IndexDocumentGenerator.java
+++ b/search-commons/src/main/java/no/unit/nva/search/IndexDocumentGenerator.java
@@ -1,5 +1,8 @@
 package no.unit.nva.search;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static nva.commons.core.StringUtils.isEmpty;
 import com.amazonaws.services.dynamodbv2.document.ItemUtils;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
@@ -7,14 +10,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.model.Reference;
-import no.unit.nva.utils.DynamodbItemUtilsClone;
-import nva.commons.core.JacocoGenerated;
-import nva.commons.core.JsonUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
@@ -28,10 +23,13 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
-import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
-import static nva.commons.core.StringUtils.isEmpty;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.model.Reference;
+import no.unit.nva.utils.DynamodbItemUtilsClone;
+import nva.commons.core.JacocoGenerated;
+import nva.commons.core.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("PMD.GodClass")
 public final class IndexDocumentGenerator extends IndexDocument {

--- a/search-commons/src/main/java/no/unit/nva/search/IndexPublisher.java
+++ b/search-commons/src/main/java/no/unit/nva/search/IndexPublisher.java
@@ -2,11 +2,10 @@ package no.unit.nva.search;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import no.unit.nva.model.Organization;
-import nva.commons.core.JacocoGenerated;
-
 import java.net.URI;
 import java.util.Objects;
+import no.unit.nva.model.Organization;
+import nva.commons.core.JacocoGenerated;
 
 public class IndexPublisher {
 

--- a/search-commons/src/main/java/no/unit/nva/search/IndicesClientWrapper.java
+++ b/search-commons/src/main/java/no/unit/nva/search/IndicesClientWrapper.java
@@ -1,0 +1,27 @@
+package no.unit.nva.search;
+
+import java.io.IOException;
+import nva.commons.core.JacocoGenerated;
+import org.elasticsearch.client.IndicesClient;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.CreateIndexResponse;
+
+/**
+ * Wrapper class for being able to test calls to the final class IndicesClient.
+ */
+@JacocoGenerated
+public class IndicesClientWrapper {
+
+    private final IndicesClient indicesClient;
+
+
+    public IndicesClientWrapper(IndicesClient indices) {
+        this.indicesClient = indices;
+    }
+
+    public CreateIndexResponse create(CreateIndexRequest createIndexRequest, RequestOptions requestOptions)
+        throws IOException {
+        return indicesClient.create(createIndexRequest, requestOptions);
+    }
+}

--- a/search-commons/src/main/java/no/unit/nva/search/RestHighLevelClientWrapper.java
+++ b/search-commons/src/main/java/no/unit/nva/search/RestHighLevelClientWrapper.java
@@ -24,41 +24,47 @@ public class RestHighLevelClientWrapper {
     private final RestHighLevelClient client;
     private final static Logger logger = LoggerFactory.getLogger(RestHighLevelClientWrapper.class);
 
-    public RestHighLevelClientWrapper(RestHighLevelClient client){
+    public RestHighLevelClientWrapper(RestHighLevelClient client) {
         this.client = client;
     }
 
     public RestHighLevelClientWrapper(RestClientBuilder clientBuilder) {
-        this.client= new RestHighLevelClient(clientBuilder);
+        this.client = new RestHighLevelClient(clientBuilder);
     }
 
     /**
      * Use this method only to experiment and to extend the functionality of the wrapper.
+     *
      * @return the contained client
      */
-    public RestHighLevelClient getClient(){
+    @JacocoGenerated
+    public RestHighLevelClient getClient() {
         logger.warn("Use getClient only for finding which methods you need to add to the wrapper");
         return this.client;
     }
 
     @JacocoGenerated
     public SearchResponse search(SearchRequest searchRequest, RequestOptions requestOptions) throws IOException {
-        return client.search(searchRequest,requestOptions);
+        return client.search(searchRequest, requestOptions);
     }
-
 
     @JacocoGenerated
     public IndexResponse index(IndexRequest updateRequest, RequestOptions requestOptions) throws IOException {
-        return client.index(updateRequest,requestOptions);
+        return client.index(updateRequest, requestOptions);
     }
 
     @JacocoGenerated
     public DeleteResponse delete(DeleteRequest deleteRequest, RequestOptions requestOptions) throws IOException {
-        return client.delete(deleteRequest,requestOptions);
+        return client.delete(deleteRequest, requestOptions);
     }
 
     @JacocoGenerated
     public UpdateResponse update(UpdateRequest updateRequest, RequestOptions requestOptions) throws IOException {
-        return client.update(updateRequest,requestOptions);
+        return client.update(updateRequest, requestOptions);
+    }
+
+    @JacocoGenerated
+    public IndicesClientWrapper indices() {
+        return new IndicesClientWrapper(client.indices());
     }
 }

--- a/search-commons/src/main/java/no/unit/nva/search/RestHighLevelClientWrapper.java
+++ b/search-commons/src/main/java/no/unit/nva/search/RestHighLevelClientWrapper.java
@@ -1,0 +1,64 @@
+package no.unit.nva.search;
+
+import java.io.IOException;
+import nva.commons.core.JacocoGenerated;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class for avoiding mocking/spying the ES final classes.
+ */
+public class RestHighLevelClientWrapper {
+
+    private final RestHighLevelClient client;
+    private final static Logger logger = LoggerFactory.getLogger(RestHighLevelClientWrapper.class);
+
+    public RestHighLevelClientWrapper(RestHighLevelClient client){
+        this.client = client;
+    }
+
+    public RestHighLevelClientWrapper(RestClientBuilder clientBuilder) {
+        this.client= new RestHighLevelClient(clientBuilder);
+    }
+
+    /**
+     * Use this method only to experiment and to extend the functionality of the wrapper.
+     * @return the contained client
+     */
+    public RestHighLevelClient getClient(){
+        logger.warn("Use getClient only for finding which methods you need to add to the wrapper");
+        return this.client;
+    }
+
+    @JacocoGenerated
+    public SearchResponse search(SearchRequest searchRequest, RequestOptions requestOptions) throws IOException {
+        return client.search(searchRequest,requestOptions);
+    }
+
+
+    @JacocoGenerated
+    public IndexResponse index(IndexRequest updateRequest, RequestOptions requestOptions) throws IOException {
+        return client.index(updateRequest,requestOptions);
+    }
+
+    @JacocoGenerated
+    public DeleteResponse delete(DeleteRequest deleteRequest, RequestOptions requestOptions) throws IOException {
+        return client.delete(deleteRequest,requestOptions);
+    }
+
+    @JacocoGenerated
+    public UpdateResponse update(UpdateRequest updateRequest, RequestOptions requestOptions) throws IOException {
+        return client.update(updateRequest,requestOptions);
+    }
+}

--- a/search-commons/src/main/java/no/unit/nva/search/SearchResourcesResponse.java
+++ b/search-commons/src/main/java/no/unit/nva/search/SearchResourcesResponse.java
@@ -4,11 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonNode;
-import nva.commons.core.JacocoGenerated;
-
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
+import nva.commons.core.JacocoGenerated;
 
 @JsonPropertyOrder({"@context", "took","email", "total", "hits" })
 public class SearchResourcesResponse {

--- a/search-commons/src/main/java/no/unit/nva/search/exception/InputException.java
+++ b/search-commons/src/main/java/no/unit/nva/search/exception/InputException.java
@@ -1,7 +1,6 @@
 package no.unit.nva.search.exception;
 
 import nva.commons.apigateway.exceptions.ApiGatewayException;
-
 import org.apache.http.HttpStatus;
 
 public class InputException extends ApiGatewayException {

--- a/search-commons/src/main/java/no/unit/nva/utils/DynamodbItemUtilsClone.java
+++ b/search-commons/src/main/java/no/unit/nva/utils/DynamodbItemUtilsClone.java
@@ -1,16 +1,11 @@
 package no.unit.nva.utils;
 
+import static com.amazonaws.util.BinaryUtils.copyAllBytesFrom;
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import no.unit.nva.model.Publication;
-import nva.commons.core.JacocoGenerated;
-import nva.commons.core.JsonUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -19,8 +14,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static com.amazonaws.util.BinaryUtils.copyAllBytesFrom;
+import no.unit.nva.model.Publication;
+import nva.commons.core.JacocoGenerated;
+import nva.commons.core.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This methods in this class is lend from com.amazonaws.services.dynamodbv2.document.ItemUtils

--- a/search-commons/src/test/java/no/unit/nva/search/ElasticsearchSigningHighLevelRestClientTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/ElasticsearchSigningHighLevelRestClientTest.java
@@ -3,13 +3,8 @@ package no.unit.nva.search;
 import static no.unit.nva.search.ElasticSearchHighLevelRestClient.ELASTICSEARCH_ENDPOINT_ADDRESS_KEY;
 import static no.unit.nva.search.ElasticSearchHighLevelRestClient.ELASTICSEARCH_ENDPOINT_API_SCHEME_KEY;
 import static no.unit.nva.search.ElasticSearchHighLevelRestClient.ELASTICSEARCH_ENDPOINT_INDEX_KEY;
-import static no.unit.nva.search.ElasticSearchHighLevelRestClient.ELASTICSEARCH_ENDPOINT_REGION_KEY;
 import static nva.commons.core.ioutils.IoUtils.inputStreamFromResources;
 import static nva.commons.core.ioutils.IoUtils.streamToString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -18,7 +13,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.io.IOException;
-import java.util.List;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.search.exception.SearchException;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -84,7 +78,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
         when(searchResponse.toString()).thenReturn(SAMPLE_JSON_RESPONSE);
         when(restHighLevelClient.search(any(), any())).thenReturn(searchResponse);
         ElasticSearchHighLevelRestClient elasticSearchRestClient =
-                new ElasticSearchHighLevelRestClient(environment, restHighLevelClient);
+                new ElasticSearchHighLevelRestClient(environment, new RestHighLevelClientWrapper(restHighLevelClient));
         SearchResourcesResponse searchResourcesResponse =
                 elasticSearchRestClient.searchSingleTerm(SAMPLE_TERM,
                         SAMPLE_NUMBER_OF_RESULTS,
@@ -97,7 +91,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
     @Test
     void searchSingleTermReturnsResponseWithStatsFromElastic() throws ApiGatewayException, IOException {
 
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         SearchResponse searchResponse = mock(SearchResponse.class);
         String elasticSearchResponseJson = getElasticSEarchResponseAsString();
         when(searchResponse.toString()).thenReturn(elasticSearchResponseJson);
@@ -122,7 +116,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
     @Test
     void searchSingleTermReturnsErrorResponseWhenExceptionInDoSearch() throws ApiGatewayException, IOException {
 
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         when(restHighLevelClient.search(any(), any())).thenThrow(new IOException());
 
         ElasticSearchHighLevelRestClient elasticSearchRestClient =
@@ -143,7 +137,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
 
         IndexDocument indexDocument = mock(IndexDocument.class);
         doThrow(RuntimeException.class).when(indexDocument).toJsonString();
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         when(restHighLevelClient.update(any(), any())).thenThrow(new RuntimeException());
         ElasticSearchHighLevelRestClient elasticSearchRestClient =
                 new ElasticSearchHighLevelRestClient(environment, restHighLevelClient);
@@ -156,7 +150,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
 
         IndexDocument indexDocument = mock(IndexDocument.class);
         doThrow(RuntimeException.class).when(indexDocument).toJsonString();
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         when(restHighLevelClient.update(any(), any())).thenThrow(new RuntimeException());
         ElasticSearchHighLevelRestClient elasticSearchRestClient =
                 new ElasticSearchHighLevelRestClient(environment, restHighLevelClient);
@@ -168,7 +162,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
     void removeDocumentReturnsDocumentNotFoundWhenNoDocumentMatchesIdentifier() throws IOException,
             SearchException {
 
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         DeleteResponse nothingFoundResponse = mock(DeleteResponse.class);
         when(nothingFoundResponse.getResult()).thenReturn(DocWriteResponse.Result.NOT_FOUND);
         when(restHighLevelClient.delete(any(), any())).thenReturn(nothingFoundResponse);
@@ -184,7 +178,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
         IndexDocument mockDocument = mock(IndexDocument.class);
         when(mockDocument.toJsonString()).thenReturn("{}");
         when(mockDocument.getId()).thenReturn(SortableIdentifier.next());
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         when(restHighLevelClient.update(any(), any())).thenReturn(updateResponse);
 
         ElasticSearchHighLevelRestClient elasticSearchRestClient =

--- a/search-commons/src/test/java/no/unit/nva/search/IndexDocumentGeneratorTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/IndexDocumentGeneratorTest.java
@@ -1,8 +1,23 @@
 package no.unit.nva.search;
 
+import static no.unit.nva.search.IndexDocumentGenerator.ABSTRACT;
+import static no.unit.nva.search.IndexDocumentGenerator.DESCRIPTION;
+import static no.unit.nva.search.IndexDocumentGenerator.PUBLISHED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import no.unit.nva.model.Reference;
 import no.unit.nva.model.contexttypes.Book;
 import no.unit.nva.model.contexttypes.PublicationContext;
@@ -10,24 +25,6 @@ import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.book.BookMonograph;
 import nva.commons.core.JsonUtils;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.net.URI;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static no.unit.nva.search.IndexDocumentGenerator.ABSTRACT;
-import static no.unit.nva.search.IndexDocumentGenerator.DESCRIPTION;
-import static no.unit.nva.search.IndexDocumentGenerator.PUBLISHED;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 public class IndexDocumentGeneratorTest {

--- a/search-commons/src/test/java/no/unit/nva/search/SearchResourcesResponseTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/SearchResourcesResponseTest.java
@@ -1,13 +1,11 @@
 package no.unit.nva.search;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.jupiter.api.Test;
-
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
 
 class SearchResourcesResponseTest {
 

--- a/search-commons/src/test/java/no/unit/nva/utils/DynamodbItemUtilsCloneTest.java
+++ b/search-commons/src/test/java/no/unit/nva/utils/DynamodbItemUtilsCloneTest.java
@@ -1,17 +1,15 @@
 package no.unit.nva.utils;
 
+import static nva.commons.core.ioutils.IoUtils.inputStreamFromResources;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import no.unit.nva.model.Publication;
-import nva.commons.core.JacocoGenerated;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.stream.Collectors;
-
-import static nva.commons.core.ioutils.IoUtils.inputStreamFromResources;
+import no.unit.nva.model.Publication;
+import nva.commons.core.JacocoGenerated;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 @JacocoGenerated
 public class DynamodbItemUtilsCloneTest {

--- a/search-resources-api/src/main/java/no/unit/nva/search/SearchResourcesApiHandler.java
+++ b/search-resources-api/src/main/java/no/unit/nva/search/SearchResourcesApiHandler.java
@@ -1,5 +1,10 @@
 package no.unit.nva.search;
 
+import static no.unit.nva.search.RequestUtil.getFrom;
+import static no.unit.nva.search.RequestUtil.getOrderBy;
+import static no.unit.nva.search.RequestUtil.getResults;
+import static no.unit.nva.search.RequestUtil.getSearchTerm;
+import static no.unit.nva.search.RequestUtil.getSortOrder;
 import com.amazonaws.services.lambda.runtime.Context;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -10,12 +15,6 @@ import nva.commons.core.JacocoGenerated;
 import nva.commons.core.JsonUtils;
 import org.apache.http.HttpStatus;
 import org.elasticsearch.search.sort.SortOrder;
-
-import static no.unit.nva.search.RequestUtil.getFrom;
-import static no.unit.nva.search.RequestUtil.getOrderBy;
-import static no.unit.nva.search.RequestUtil.getResults;
-import static no.unit.nva.search.RequestUtil.getSearchTerm;
-import static no.unit.nva.search.RequestUtil.getSortOrder;
 
 public class SearchResourcesApiHandler extends ApiGatewayHandler<Void, SearchResourcesResponse> {
 

--- a/search-resources-api/src/test/java/no/unit/nva/search/ElasticsearchSigningHighLevelRestClientTest.java
+++ b/search-resources-api/src/test/java/no/unit/nva/search/ElasticsearchSigningHighLevelRestClientTest.java
@@ -1,21 +1,5 @@
 package no.unit.nva.search;
 
-import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.search.exception.SearchException;
-import nva.commons.apigateway.exceptions.ApiGatewayException;
-import nva.commons.core.Environment;
-import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.action.delete.DeleteResponse;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.update.UpdateResponse;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.search.sort.SortOrder;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.UUID;
-
 import static no.unit.nva.search.ElasticSearchHighLevelRestClient.ELASTICSEARCH_ENDPOINT_ADDRESS_KEY;
 import static no.unit.nva.search.ElasticSearchHighLevelRestClient.ELASTICSEARCH_ENDPOINT_API_SCHEME_KEY;
 import static no.unit.nva.search.ElasticSearchHighLevelRestClient.ELASTICSEARCH_ENDPOINT_INDEX_KEY;
@@ -25,6 +9,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import java.io.IOException;
+import no.unit.nva.identifiers.SortableIdentifier;
+import no.unit.nva.search.exception.SearchException;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.core.Environment;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.search.sort.SortOrder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ElasticsearchSigningHighLevelRestClientTest {
 
@@ -70,7 +66,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
     @Test
     void searchSingleTermReturnsResponse() throws ApiGatewayException, IOException {
 
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         SearchResponse searchResponse = mock(SearchResponse.class);
         when(searchResponse.toString()).thenReturn(SAMPLE_JSON_RESPONSE);
         when(restHighLevelClient.search(any(), any())).thenReturn(searchResponse);
@@ -131,7 +127,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
         IndexDocument mockDocument = mock(IndexDocument.class);
         when(mockDocument.toJsonString()).thenReturn("{}");
         when(mockDocument.getId()).thenReturn(SortableIdentifier.next());
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         when(restHighLevelClient.update(any(), any())).thenReturn(updateResponse);
 
         ElasticSearchHighLevelRestClient elasticSearchRestClient =

--- a/search-resources-api/src/test/java/no/unit/nva/search/ElasticsearchSigningHighLevelRestClientTest.java
+++ b/search-resources-api/src/test/java/no/unit/nva/search/ElasticsearchSigningHighLevelRestClientTest.java
@@ -90,7 +90,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
 
         IndexDocument indexDocument = mock(IndexDocument.class);
         doThrow(RuntimeException.class).when(indexDocument).toJsonString();
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         when(restHighLevelClient.update(any(), any())).thenThrow(new RuntimeException());
         ElasticSearchHighLevelRestClient elasticSearchRestClient =
                 new ElasticSearchHighLevelRestClient(environment, restHighLevelClient);
@@ -103,7 +103,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
 
         IndexDocument indexDocument = mock(IndexDocument.class);
         doThrow(RuntimeException.class).when(indexDocument).toJsonString();
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         when(restHighLevelClient.update(any(), any())).thenThrow(new RuntimeException());
         ElasticSearchHighLevelRestClient elasticSearchRestClient =
                 new ElasticSearchHighLevelRestClient(environment, restHighLevelClient);
@@ -115,7 +115,7 @@ public class ElasticsearchSigningHighLevelRestClientTest {
     void removeDocumentReturnsDocumentNotFoundWhenNoDocumentMatchesIdentifier() throws IOException,
             SearchException {
 
-        RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
+        RestHighLevelClientWrapper restHighLevelClient = mock(RestHighLevelClientWrapper.class);
         DeleteResponse nothingFoundResponse = mock(DeleteResponse.class);
         when(nothingFoundResponse.getResult()).thenReturn(DocWriteResponse.Result.NOT_FOUND);
         when(restHighLevelClient.delete(any(), any())).thenReturn(nothingFoundResponse);

--- a/search-resources-api/src/test/java/no/unit/nva/search/SearchResourcesApiHandlerTest.java
+++ b/search-resources-api/src/test/java/no/unit/nva/search/SearchResourcesApiHandlerTest.java
@@ -1,30 +1,5 @@
 package no.unit.nva.search;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import nva.commons.apigateway.GatewayResponse;
-import nva.commons.apigateway.RequestInfo;
-import nva.commons.apigateway.exceptions.ApiGatewayException;
-import nva.commons.core.Environment;
-import nva.commons.core.JsonUtils;
-import nva.commons.core.ioutils.IoUtils;
-import org.apache.http.HttpStatus;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.Charset;
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import static no.unit.nva.search.ElasticSearchHighLevelRestClient.ELASTICSEARCH_ENDPOINT_ADDRESS_KEY;
 import static no.unit.nva.search.ElasticSearchHighLevelRestClient.ELASTICSEARCH_ENDPOINT_API_SCHEME_KEY;
 import static no.unit.nva.search.ElasticSearchHighLevelRestClient.ELASTICSEARCH_ENDPOINT_INDEX_KEY;
@@ -38,6 +13,29 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import nva.commons.apigateway.GatewayResponse;
+import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.core.Environment;
+import nva.commons.core.JsonUtils;
+import nva.commons.core.ioutils.IoUtils;
+import org.apache.http.HttpStatus;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class SearchResourcesApiHandlerTest {
 
@@ -128,27 +126,27 @@ public class SearchResourcesApiHandlerTest {
         return requestInfo;
     }
 
-    private RestHighLevelClient setUpRestHighLevelClient() throws IOException {
+    private RestHighLevelClientWrapper setUpRestHighLevelClient() throws IOException {
         String result = stringFromResources(Path.of(SAMPLE_ELASTICSEARCH_RESPONSE_JSON));
         SearchResponse searchResponse = getSearchResponse(result);
         RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
         when(restHighLevelClient.search(any(), any())).thenReturn(searchResponse);
-        return restHighLevelClient;
+        return new RestHighLevelClientWrapper(restHighLevelClient);
     }
 
-    private RestHighLevelClient setUpRestHighLevelClientWithEmptyResponse() throws IOException {
+    private RestHighLevelClientWrapper setUpRestHighLevelClientWithEmptyResponse() throws IOException {
         String result = stringFromResources(Path.of(EMPTY_ELASTICSEARCH_RESPONSE_JSON));
         SearchResponse searchResponse = getSearchResponse(result);
         RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
         when(restHighLevelClient.search(any(), any())).thenReturn(searchResponse);
-        return restHighLevelClient;
+        return new RestHighLevelClientWrapper(restHighLevelClient);
     }
 
 
-    private RestHighLevelClient setUpBadGateWay() throws IOException {
+    private RestHighLevelClientWrapper setUpBadGateWay() throws IOException {
         RestHighLevelClient restHighLevelClient = mock(RestHighLevelClient.class);
         when(restHighLevelClient.search(any(), any())).thenThrow(IOException.class);
-        return restHighLevelClient;
+        return new RestHighLevelClientWrapper(restHighLevelClient);
     }
 
     private SearchResponse getSearchResponse(String hits) {

--- a/search-resources-dynamodb-trigger/build.gradle
+++ b/search-resources-dynamodb-trigger/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     testImplementation group: 'org.testcontainers', name: 'testcontainers', version: project.ext.testContainersVersion
     testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: project.ext.testContainersVersion
-    testCompile group: 'org.testcontainers', name: 'elasticsearch', version: project.ext.testContainersVersion
+    testCompileOnly group: 'org.testcontainers', name: 'elasticsearch', version: project.ext.testContainersVersion
 
 
 

--- a/search-resources-dynamodb-trigger/build.gradle
+++ b/search-resources-dynamodb-trigger/build.gradle
@@ -3,12 +3,11 @@ dependencies {
     testImplementation project(':search-commons')
 
     implementation group: 'com.github.bibsysdev', name: 'eventhandlers', version: project.ext.nvaCommonsVersion
-    // used for integration tests, to run spin-up a local elastic-search.
 
+
+    // used for integration tests, to run spin-up a local elastic-search.
     testImplementation group: 'org.testcontainers', name: 'testcontainers', version: project.ext.testContainersVersion
     testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: project.ext.testContainersVersion
-    testCompileOnly group: 'org.testcontainers', name: 'elasticsearch', version: project.ext.testContainersVersion
-
-
+    testImplementation group: 'org.testcontainers', name: 'elasticsearch', version: project.ext.testContainersVersion
 
 }

--- a/search-resources-dynamodb-trigger/src/test/java/no/unit/nva/publication/Contributor.java
+++ b/search-resources-dynamodb-trigger/src/test/java/no/unit/nva/publication/Contributor.java
@@ -1,8 +1,7 @@
 package no.unit.nva.publication;
 
-import no.unit.nva.search.IndexContributor;
-
 import java.net.URI;
+import no.unit.nva.search.IndexContributor;
 
 /**
  * Class provided to simplify creation of objects for testing. Clones some functionality from nva-datamodel-java.

--- a/search-resources-dynamodb-trigger/src/test/java/no/unit/nva/publication/PublicationUpdateEventHandlerTest.java
+++ b/search-resources-dynamodb-trigger/src/test/java/no/unit/nva/publication/PublicationUpdateEventHandlerTest.java
@@ -44,6 +44,7 @@ import no.unit.nva.model.PublicationStatus;
 import no.unit.nva.model.exceptions.InvalidIssnException;
 import no.unit.nva.search.ElasticSearchHighLevelRestClient;
 import no.unit.nva.search.IndexDocument;
+import no.unit.nva.search.RestHighLevelClientWrapper;
 import no.unit.nva.search.SearchResourcesResponse;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
@@ -96,7 +97,7 @@ public class PublicationUpdateEventHandlerTest {
     private Context context;
     private Environment environment;
     private TestAppender testAppender;
-    private RestHighLevelClient restClient;
+    private RestHighLevelClientWrapper restClient;
     private ByteArrayOutputStream output;
     private TestDataGenerator dataGenerator;
     private ElasticSearchHighLevelRestClient elasticSearchRestClient;
@@ -379,12 +380,12 @@ public class PublicationUpdateEventHandlerTest {
         }
     }
 
-    private RestHighLevelClient mockElasticSearch() throws IOException {
+    private RestHighLevelClientWrapper mockElasticSearch() throws IOException {
         RestHighLevelClient client = mock(RestHighLevelClient.class);
         DeleteResponse fakeDeleteResponse = mockDeleteResponse();
         when(client.delete(any(DeleteRequest.class), any(RequestOptions.class)))
             .thenReturn(fakeDeleteResponse);
-        return client;
+        return new RestHighLevelClientWrapper(client);
     }
 
     private DeleteResponse mockDeleteResponse() {

--- a/search-resources-dynamodb-trigger/src/test/java/no/unit/nva/publication/TestDataGenerator.java
+++ b/search-resources-dynamodb-trigger/src/test/java/no/unit/nva/publication/TestDataGenerator.java
@@ -1,8 +1,8 @@
 package no.unit.nva.publication;
 
 import static no.unit.nva.model.PublicationStatus.PUBLISHED;
-import static no.unit.nva.publication.PublicationUpdateEventHandler.REMOVE;
 import static no.unit.nva.publication.PublicationGenerator.randomString;
+import static no.unit.nva.publication.PublicationUpdateEventHandler.REMOVE;
 import static nva.commons.core.JsonUtils.objectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.core.JsonPointer;


### PR DESCRIPTION
In a later PR I want to use the IndicesClient that is contained in the HighLeverElasticSearch client. Unfortunately this class is final and cannot be spied or mocked. That makes difficult to test whether the method that is calling this client is  actually doing what is supposed to do.  To solve this problem, I created two wrapper (imposter) classes that have the same functionality but can be mocked/spied