### PR TITLE
Np 3522 add viewing scope parameter to search

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -17,40 +17,18 @@ paths:
       parameters:
         - in: path
           name: index
-          description: "Index to search for resource in."
+          description: "Index to search for resources in."
           required: true
           schema:
             type: string
         - in: query
-          name: query
-          description: "Term to search for in resource."
+          name: viewingScope
+          description: "List resources for this organization."
           required: false
           schema:
             type: string
-        - in: query
-          name: orderBy
-          description: "Field to order result by."
-          required: false
-          schema:
-            type: string
-        - in: query
-          name: sortOrder
-          description: "Order of search results (asc or desc)."
-          required: false
-          schema:
-            type: string
-        - in: query
-          name: from
-          description: "Start position from results, 0-based."
-          required: false
-          schema:
-            type: string
-        - in: query
-          name: results
-          description: "Maximum number of resources in response."
-          required: false
-          schema:
-            type: string
+            format: uri
+            example: "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
       security:
         - CognitoUserPool: [ ]
       x-amazon-apigateway-integration:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -17,10 +17,11 @@ paths:
       parameters:
         - in: path
           name: index
-          description: "Index to search for resources in."
+          description: "Index for NVA-resources related to publications"
           required: true
           schema:
             type: string
+            enum: [doirequests,messages]
         - in: query
           name: viewingScope
           description: "List resources for this organization."

--- a/search-commons/src/main/java/no/unit/nva/search/SearchClient.java
+++ b/search-commons/src/main/java/no/unit/nva/search/SearchClient.java
@@ -68,10 +68,9 @@ public class SearchClient {
 
     private BoolQueryBuilder matchOneOfOrganizationIdsQuery(UserResponse.ViewingScope viewingScope) {
         BoolQueryBuilder queryBuilder = new BoolQueryBuilder()
-            .must(existsQuery(ORGANIZATION_IDS))
-            .minimumShouldMatch(1);
+            .must(existsQuery(ORGANIZATION_IDS));
         for (URI includedOrganizationId : viewingScope.getIncludedUnits()) {
-            queryBuilder.should(matchPhraseQuery(ORGANIZATION_IDS, includedOrganizationId.toString()));
+            queryBuilder.must(matchPhraseQuery(ORGANIZATION_IDS, includedOrganizationId.toString()));
         }
         for (URI excludedOrganizationId : viewingScope.getExcludedUnits()) {
             queryBuilder.mustNot(matchPhraseQuery(ORGANIZATION_IDS, excludedOrganizationId.toString()));

--- a/search-commons/src/main/java/no/unit/nva/search/SearchClient.java
+++ b/search-commons/src/main/java/no/unit/nva/search/SearchClient.java
@@ -1,8 +1,13 @@
 package no.unit.nva.search;
 
+import static no.unit.nva.search.models.SearchResourcesResponse.toSearchResourcesResponse;
+import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchPhraseQuery;
+import java.io.IOException;
+import java.net.URI;
 import no.unit.nva.search.models.Query;
 import no.unit.nva.search.models.SearchResourcesResponse;
-import no.unit.nva.search.restclients.responses.UserResponse;
+import no.unit.nva.search.restclients.responses.ViewingScope;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadGatewayException;
 import org.elasticsearch.action.search.SearchRequest;
@@ -11,13 +16,6 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-
-import java.io.IOException;
-import java.net.URI;
-
-import static no.unit.nva.search.models.SearchResourcesResponse.toSearchResourcesResponse;
-import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchPhraseQuery;
 
 public class SearchClient {
 
@@ -48,7 +46,7 @@ public class SearchClient {
         return toSearchResourcesResponse(query.getRequestUri(), query.getSearchTerm(), searchResponse.toString());
     }
 
-    public SearchResponse findResourcesForOrganizationIds(String index, UserResponse.ViewingScope viewingScope)
+    public SearchResponse findResourcesForOrganizationIds(String index, ViewingScope viewingScope)
             throws BadGatewayException {
         try {
             SearchRequest searchRequest = createSearchRequestForResourcesWithOrganizationIds(index, viewingScope);
@@ -59,14 +57,14 @@ public class SearchClient {
     }
 
     private SearchRequest createSearchRequestForResourcesWithOrganizationIds(
-            String index, UserResponse.ViewingScope viewingScope) {
+            String index, ViewingScope viewingScope) {
         BoolQueryBuilder queryBuilder = matchOneOfOrganizationIdsQuery(viewingScope);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
             .query(queryBuilder);
         return new SearchRequest(index).source(searchSourceBuilder);
     }
 
-    private BoolQueryBuilder matchOneOfOrganizationIdsQuery(UserResponse.ViewingScope viewingScope) {
+    private BoolQueryBuilder matchOneOfOrganizationIdsQuery(ViewingScope viewingScope) {
         BoolQueryBuilder queryBuilder = new BoolQueryBuilder()
             .must(existsQuery(ORGANIZATION_IDS));
         for (URI includedOrganizationId : viewingScope.getIncludedUnits()) {

--- a/search-commons/src/main/java/no/unit/nva/search/restclients/responses/UserResponse.java
+++ b/search-commons/src/main/java/no/unit/nva/search/restclients/responses/UserResponse.java
@@ -1,14 +1,8 @@
 package no.unit.nva.search.restclients.responses;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import java.net.URI;
-import java.util.Collections;
-import java.util.Set;
-import org.elasticsearch.common.recycler.Recycler.V;
-
 import static no.unit.nva.search.constants.ApplicationConstants.objectMapperNoEmpty;
 import static nva.commons.core.attempt.Try.attempt;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 public class UserResponse {
 
@@ -29,43 +23,4 @@ public class UserResponse {
     public String toJson() {
         return attempt(() -> objectMapperNoEmpty.writeValueAsString(this)).orElseThrow();
     }
-
-    public static class ViewingScope {
-
-        private Set<URI> includedUnits;
-        private Set<URI> excludedUnits;
-        private boolean recursive;
-
-        public static ViewingScope create(URI... includedUnits){
-            var viewingScope = new ViewingScope();
-            viewingScope.setIncludedUnits(Set.of(includedUnits));
-            return viewingScope;
-        }
-
-        public Set<URI> getIncludedUnits() {
-            return includedUnits != null ? includedUnits : Collections.emptySet();
-        }
-
-        public void setIncludedUnits(Set<URI> includedUnits) {
-            this.includedUnits = includedUnits;
-        }
-
-        public Set<URI> getExcludedUnits() {
-            return excludedUnits != null ? excludedUnits : Collections.emptySet();
-
-        }
-
-        public void setExcludedUnits(Set<URI> excludedUnits) {
-            this.excludedUnits = excludedUnits;
-        }
-
-        public boolean isRecursive() {
-            return recursive;
-        }
-
-        public void setRecursive(boolean recursive) {
-            this.recursive = recursive;
-        }
-    }
-
 }

--- a/search-commons/src/main/java/no/unit/nva/search/restclients/responses/UserResponse.java
+++ b/search-commons/src/main/java/no/unit/nva/search/restclients/responses/UserResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Set;
+import org.elasticsearch.common.recycler.Recycler.V;
 
 import static no.unit.nva.search.constants.ApplicationConstants.objectMapperNoEmpty;
 import static nva.commons.core.attempt.Try.attempt;
@@ -34,6 +35,12 @@ public class UserResponse {
         private Set<URI> includedUnits;
         private Set<URI> excludedUnits;
         private boolean recursive;
+
+        public static ViewingScope create(URI... includedUnits){
+            var viewingScope = new ViewingScope();
+            viewingScope.setIncludedUnits(Set.of(includedUnits));
+            return viewingScope;
+        }
 
         public Set<URI> getIncludedUnits() {
             return includedUnits != null ? includedUnits : Collections.emptySet();

--- a/search-commons/src/main/java/no/unit/nva/search/restclients/responses/ViewingScope.java
+++ b/search-commons/src/main/java/no/unit/nva/search/restclients/responses/ViewingScope.java
@@ -1,0 +1,43 @@
+package no.unit.nva.search.restclients.responses;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Set;
+
+public  class ViewingScope {
+
+    private Set<URI> includedUnits;
+    private Set<URI> excludedUnits;
+    private boolean recursive;
+
+    public static ViewingScope create(URI... includedUnits){
+        var viewingScope = new ViewingScope();
+        viewingScope.setIncludedUnits(Set.of(includedUnits));
+        return viewingScope;
+    }
+
+    public Set<URI> getIncludedUnits() {
+        return includedUnits != null ? includedUnits : Collections.emptySet();
+    }
+
+    public void setIncludedUnits(Set<URI> includedUnits) {
+        this.includedUnits = includedUnits;
+    }
+
+    public Set<URI> getExcludedUnits() {
+        return excludedUnits != null ? excludedUnits : Collections.emptySet();
+
+    }
+
+    public void setExcludedUnits(Set<URI> excludedUnits) {
+        this.excludedUnits = excludedUnits;
+    }
+
+    public boolean isRecursive() {
+        return recursive;
+    }
+
+    public void setRecursive(boolean recursive) {
+        this.recursive = recursive;
+    }
+}

--- a/search-commons/src/test/java/no/unit/nva/search/ElasticsearchTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/ElasticsearchTest.java
@@ -1,10 +1,19 @@
 package no.unit.nva.search;
 
+import static no.unit.nva.search.SearchClient.APPROVED;
+import static no.unit.nva.search.SearchClient.ORGANIZATION_IDS;
+import static no.unit.nva.search.SearchClient.STATUS;
+import static no.unit.nva.search.constants.ApplicationConstants.objectMapperWithEmpty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.search.models.EventConsumptionAttributes;
 import no.unit.nva.search.models.IndexDocument;
-import no.unit.nva.search.restclients.responses.UserResponse;
+import no.unit.nva.search.restclients.responses.ViewingScope;
 import no.unit.nva.testutils.RandomDataGenerator;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.search.SearchResponse;
@@ -17,17 +26,6 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-
-import java.net.URI;
-import java.util.Map;
-import java.util.Set;
-
-import static no.unit.nva.search.SearchClient.APPROVED;
-import static no.unit.nva.search.SearchClient.ORGANIZATION_IDS;
-import static no.unit.nva.search.SearchClient.STATUS;
-import static no.unit.nva.search.constants.ApplicationConstants.objectMapperWithEmpty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 @Testcontainers
 public class ElasticsearchTest {
@@ -81,7 +79,7 @@ public class ElasticsearchTest {
 
         Thread.sleep(DELAY_AFTER_INDEXING);
 
-        UserResponse.ViewingScope viewingScope = getEmptyViewingScope();
+        ViewingScope viewingScope = getEmptyViewingScope();
         viewingScope.setIncludedUnits(Set.of(INCLUDED_ORGANIZATION_ID));
 
         SearchResponse response = searchClient.findResourcesForOrganizationIds(INDEX_NAME, viewingScope);
@@ -98,7 +96,7 @@ public class ElasticsearchTest {
 
         Thread.sleep(DELAY_AFTER_INDEXING);
 
-        UserResponse.ViewingScope viewingScope = getEmptyViewingScope();
+        ViewingScope viewingScope = getEmptyViewingScope();
         viewingScope.setIncludedUnits(Set.of(INCLUDED_ORGANIZATION_ID));
 
         SearchResponse response = searchClient.findResourcesForOrganizationIds(INDEX_NAME, viewingScope);
@@ -114,7 +112,7 @@ public class ElasticsearchTest {
 
         Thread.sleep(DELAY_AFTER_INDEXING);
 
-        UserResponse.ViewingScope viewingScope = getEmptyViewingScope();
+        var viewingScope = getEmptyViewingScope();
         viewingScope.setIncludedUnits(Set.of(INCLUDED_ORGANIZATION_ID));
         viewingScope.setExcludedUnits(Set.of(EXCLUDED_ORGANIZATION_ID));
 
@@ -124,8 +122,8 @@ public class ElasticsearchTest {
                 is(equalTo(ONE_HIT_BECAUSE_ONE_UNIT_WAS_EXCLUDED)));
     }
 
-    private UserResponse.ViewingScope getEmptyViewingScope() {
-        return new UserResponse.ViewingScope();
+    private ViewingScope getEmptyViewingScope() {
+        return new ViewingScope();
     }
 
     private IndexDocument getIndexDocument(Set<URI> organizationIds) {

--- a/search-commons/src/test/java/no/unit/nva/search/SearchClientTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/SearchClientTest.java
@@ -3,6 +3,7 @@ package no.unit.nva.search;
 import no.unit.nva.search.models.Query;
 import no.unit.nva.search.models.SearchResourcesResponse;
 import no.unit.nva.search.restclients.responses.UserResponse;
+import no.unit.nva.search.restclients.responses.ViewingScope;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadGatewayException;
 import nva.commons.core.paths.UriWrapper;
@@ -78,8 +79,8 @@ public class SearchClientTest {
         assertNotNull(response);
     }
 
-    private UserResponse.ViewingScope getSampleViewingScope() {
-        UserResponse.ViewingScope viewingScope = new UserResponse.ViewingScope();
+    private ViewingScope getSampleViewingScope() {
+        ViewingScope viewingScope = new ViewingScope();
         viewingScope.setIncludedUnits(Set.of(randomUri(), randomUri()));
         viewingScope.setExcludedUnits(Set.of(randomUri()));
         return viewingScope;

--- a/search-commons/src/test/java/no/unit/nva/search/restclients/IdentityClientImplTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/restclients/IdentityClientImplTest.java
@@ -1,6 +1,7 @@
 package no.unit.nva.search.restclients;
 
 import no.unit.nva.search.restclients.responses.UserResponse;
+import no.unit.nva.search.restclients.responses.ViewingScope;
 import nva.commons.logutils.LogUtils;
 import nva.commons.logutils.TestAppender;
 import nva.commons.secrets.ErrorReadingSecretException;
@@ -78,8 +79,8 @@ class IdentityClientImplTest {
     }
 
     private UserResponse getUserResponse() {
-        UserResponse userResponse = new UserResponse();
-        UserResponse.ViewingScope viewingScope = new UserResponse.ViewingScope();
+        var userResponse = new UserResponse();
+        var viewingScope = new ViewingScope();
         viewingScope.setIncludedUnits(Set.of(randomUri(), randomUri()));
         viewingScope.setExcludedUnits(Collections.emptySet());
         userResponse.setViewingScope(viewingScope);

--- a/search-commons/src/test/java/no/unit/nva/search/restclients/responses/ViewingScopeTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/restclients/responses/ViewingScopeTest.java
@@ -1,0 +1,16 @@
+package no.unit.nva.search.restclients.responses;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import org.junit.jupiter.api.Test;
+
+public class ViewingScopeTest {
+
+    @Test
+    void shouldReturnNewViewingScopeWhenSupplyingUris() {
+        var desiredUri = randomUri();
+        var scope = ViewingScope.create(desiredUri);
+        assertThat(scope.getIncludedUnits(), contains(desiredUri));
+    }
+}

--- a/search-resources-api/src/main/java/no/unit/nva/search/SearchHandler.java
+++ b/search-resources-api/src/main/java/no/unit/nva/search/SearchHandler.java
@@ -28,8 +28,6 @@ public class SearchHandler extends ApiGatewayHandler<Void, JsonNode> {
     private final SearchClient searchClient;
     private final IdentityClient identityClient;
 
-    private final Logger logger = LoggerFactory.getLogger(SearchHandler.class);
-
     @JacocoGenerated
     public SearchHandler() {
         this(new Environment(), defaultSearchClient(), defaultIdentityClient());

--- a/search-resources-api/src/main/java/no/unit/nva/search/SearchHandler.java
+++ b/search-resources-api/src/main/java/no/unit/nva/search/SearchHandler.java
@@ -46,7 +46,6 @@ public class SearchHandler extends ApiGatewayHandler<Void, JsonNode> {
 
         String indexName = getIndexName(requestInfo);
         UserResponse.ViewingScope viewingScope = getViewingScopeForUser(requestInfo);
-
         SearchResponse searchResponse = searchClient.findResourcesForOrganizationIds(indexName, viewingScope);
         return toJsonNode(searchResponse);
     }

--- a/search-resources-api/src/main/java/no/unit/nva/search/SearchHandler.java
+++ b/search-resources-api/src/main/java/no/unit/nva/search/SearchHandler.java
@@ -1,10 +1,17 @@
 package no.unit.nva.search;
 
+import static java.net.HttpURLConnection.HTTP_OK;
+import static no.unit.nva.search.SearchClientConfig.defaultSearchClient;
+import static no.unit.nva.search.constants.ApplicationConstants.objectMapperWithEmpty;
+import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URI;
+import java.util.Optional;
 import no.unit.nva.search.restclients.IdentityClient;
 import no.unit.nva.search.restclients.IdentityClientImpl;
 import no.unit.nva.search.restclients.responses.UserResponse;
+import no.unit.nva.search.restclients.responses.UserResponse.ViewingScope;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -14,14 +21,10 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.net.HttpURLConnection.HTTP_OK;
-import static no.unit.nva.search.SearchClientConfig.defaultSearchClient;
-import static no.unit.nva.search.constants.ApplicationConstants.objectMapperWithEmpty;
-import static nva.commons.core.attempt.Try.attempt;
-
 public class SearchHandler extends ApiGatewayHandler<Void, JsonNode> {
 
     public static final String INDEX = "index";
+    public static final String VIEWING_SCOPE_QUERY_PARAMETER = "viewingScope";
     private final SearchClient searchClient;
     private final IdentityClient identityClient;
 
@@ -30,11 +33,6 @@ public class SearchHandler extends ApiGatewayHandler<Void, JsonNode> {
     @JacocoGenerated
     public SearchHandler() {
         this(new Environment(), defaultSearchClient(), defaultIdentityClient());
-    }
-
-    @JacocoGenerated
-    private static IdentityClient defaultIdentityClient() {
-        return new IdentityClientImpl();
     }
 
     public SearchHandler(Environment environment, SearchClient searchClient, IdentityClient identityClient) {
@@ -48,10 +46,19 @@ public class SearchHandler extends ApiGatewayHandler<Void, JsonNode> {
 
         String indexName = getIndexName(requestInfo);
         UserResponse.ViewingScope viewingScope = getViewingScopeForUser(requestInfo);
-        logger.info("ViewingScope for user: " + viewingScope);
 
         SearchResponse searchResponse = searchClient.findResourcesForOrganizationIds(indexName, viewingScope);
         return toJsonNode(searchResponse);
+    }
+
+    @Override
+    protected Integer getSuccessStatusCode(Void input, JsonNode output) {
+        return HTTP_OK;
+    }
+
+    @JacocoGenerated
+    private static IdentityClient defaultIdentityClient() {
+        return new IdentityClientImpl();
     }
 
     private JsonNode toJsonNode(SearchResponse searchResponse) {
@@ -59,18 +66,24 @@ public class SearchHandler extends ApiGatewayHandler<Void, JsonNode> {
     }
 
     private UserResponse.ViewingScope getViewingScopeForUser(RequestInfo requestInfo) {
+        return getUserDefinedViewingScore(requestInfo).orElseGet(() -> defaultViewingScope(requestInfo));
+    }
+
+    private ViewingScope defaultViewingScope(RequestInfo requestInfo) {
         String username = requestInfo.getFeideId().orElseThrow();
         UserResponse userResponse = identityClient.getUser(username).orElseThrow();
         return userResponse.getViewingScope();
     }
 
+    private Optional<ViewingScope> getUserDefinedViewingScore(RequestInfo requestInfo) {
+        return attempt(() -> requestInfo.getQueryParameter(VIEWING_SCOPE_QUERY_PARAMETER))
+            .map(URI::create)
+            .map(ViewingScope::create)
+            .toOptional();
+    }
+
     private String getIndexName(RequestInfo requestInfo) {
         String indexName = attempt(() -> requestInfo.getPathParameter(INDEX)).orElseThrow();
         return indexName;
-    }
-
-    @Override
-    protected Integer getSuccessStatusCode(Void input, JsonNode output) {
-        return HTTP_OK;
     }
 }

--- a/search-resources-api/src/main/java/no/unit/nva/search/SearchHandler.java
+++ b/search-resources-api/src/main/java/no/unit/nva/search/SearchHandler.java
@@ -11,15 +11,13 @@ import java.util.Optional;
 import no.unit.nva.search.restclients.IdentityClient;
 import no.unit.nva.search.restclients.IdentityClientImpl;
 import no.unit.nva.search.restclients.responses.UserResponse;
-import no.unit.nva.search.restclients.responses.UserResponse.ViewingScope;
+import no.unit.nva.search.restclients.responses.ViewingScope;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import org.elasticsearch.action.search.SearchResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SearchHandler extends ApiGatewayHandler<Void, JsonNode> {
 
@@ -43,7 +41,7 @@ public class SearchHandler extends ApiGatewayHandler<Void, JsonNode> {
     protected JsonNode processInput(Void input, RequestInfo requestInfo, Context context) throws ApiGatewayException {
 
         String indexName = getIndexName(requestInfo);
-        UserResponse.ViewingScope viewingScope = getViewingScopeForUser(requestInfo);
+        ViewingScope viewingScope = getViewingScopeForUser(requestInfo);
         SearchResponse searchResponse = searchClient.findResourcesForOrganizationIds(indexName, viewingScope);
         return toJsonNode(searchResponse);
     }
@@ -62,7 +60,7 @@ public class SearchHandler extends ApiGatewayHandler<Void, JsonNode> {
         return attempt(() -> objectMapperWithEmpty.readTree(searchResponse.toString())).orElseThrow();
     }
 
-    private UserResponse.ViewingScope getViewingScopeForUser(RequestInfo requestInfo) {
+    private ViewingScope getViewingScopeForUser(RequestInfo requestInfo) {
         return getUserDefinedViewingScore(requestInfo).orElseGet(() -> defaultViewingScope(requestInfo));
     }
 

--- a/search-resources-api/src/test/java/no/unit/nva/search/FakeRestHighLevelClientWrapper.java
+++ b/search-resources-api/src/test/java/no/unit/nva/search/FakeRestHighLevelClientWrapper.java
@@ -1,0 +1,26 @@
+package no.unit.nva.search;
+
+import java.io.IOException;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+
+public class FakeRestHighLevelClientWrapper extends RestHighLevelClientWrapper{
+
+    private SearchRequest searchRequest;
+
+    public FakeRestHighLevelClientWrapper(RestHighLevelClient client) {
+        super(client);
+    }
+
+    @Override
+    public SearchResponse search(SearchRequest searchRequest, RequestOptions requestOptions) throws IOException {
+        this.searchRequest = searchRequest;
+        return super.search(searchRequest,requestOptions);
+    }
+
+    public SearchRequest getSearchRequest(){
+        return this.searchRequest;
+    }
+}

--- a/search-resources-api/src/test/java/no/unit/nva/search/SearchHandlerTest.java
+++ b/search-resources-api/src/test/java/no/unit/nva/search/SearchHandlerTest.java
@@ -30,7 +30,7 @@ import java.util.Set;
 import no.unit.nva.indexing.testutils.SearchResponseUtil;
 import no.unit.nva.search.restclients.IdentityClient;
 import no.unit.nva.search.restclients.responses.UserResponse;
-import no.unit.nva.search.restclients.responses.UserResponse.ViewingScope;
+import no.unit.nva.search.restclients.responses.ViewingScope;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.core.Environment;
@@ -104,7 +104,7 @@ public class SearchHandlerTest {
 
     private Optional<UserResponse> getUserResponse() {
         UserResponse userResponse = new UserResponse();
-        UserResponse.ViewingScope viewingScope = new UserResponse.ViewingScope();
+        ViewingScope viewingScope = new ViewingScope();
         viewingScope.setIncludedUnits(Set.of(randomUri(), randomUri()));
         viewingScope.setExcludedUnits(Collections.emptySet());
         userResponse.setViewingScope(viewingScope);

--- a/search-resources-api/src/test/java/no/unit/nva/search/SearchHandlerTest.java
+++ b/search-resources-api/src/test/java/no/unit/nva/search/SearchHandlerTest.java
@@ -1,8 +1,7 @@
 package no.unit.nva.search;
 
 import static java.net.HttpURLConnection.HTTP_OK;
-import static no.unit.nva.search.RequestUtil.DOMAIN_NAME;
-import static no.unit.nva.search.RequestUtil.PATH;
+import static no.unit.nva.search.SearchHandler.VIEWING_SCOPE_QUERY_PARAMETER;
 import static no.unit.nva.search.constants.ApplicationConstants.objectMapperWithEmpty;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static nva.commons.core.ioutils.IoUtils.stringFromResources;
@@ -12,7 +11,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.IsNull.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -20,7 +18,6 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,7 +47,6 @@ public class SearchHandlerTest {
     public static final String MESSAGE = "message";
     public static final String INDEX = "index";
     public static final String SAMPLE_FEIDE_ID = "user@localhost";
-    public static final String VIEWING_SCOPE_QUERY_PARAMETER = "viewingScope";
 
     private IdentityClient identityClientMock;
     private SearchHandler handler;
@@ -87,7 +83,7 @@ public class SearchHandlerTest {
         final URI desiredOrgUri = randomUri();
         handler.handleRequest(queryWithCustomOrganizationAsQueryParameter(desiredOrgUri), outputStream, context);
         SearchRequest searchRequest = restHighLevelClientWrapper.getSearchRequest();
-        String queryDescription=searchRequest.buildDescription();
+        String queryDescription = searchRequest.buildDescription();
 
         final var notExpectedDefaultViewingUris = identityClientMock.getUser(SAMPLE_FEIDE_ID)
             .map(UserResponse::getViewingScope)
@@ -96,8 +92,8 @@ public class SearchHandlerTest {
 
         assertThat(queryDescription, containsString(desiredOrgUri.toString()));
 
-        for(URI notExpectedUri:notExpectedDefaultViewingUris){
-            assertThat(queryDescription,not(containsString(notExpectedUri.toString())));
+        for (URI notExpectedUri : notExpectedDefaultViewingUris) {
+            assertThat(queryDescription, not(containsString(notExpectedUri.toString())));
         }
     }
 
@@ -135,7 +131,6 @@ public class SearchHandlerTest {
             .withFeideId(SAMPLE_FEIDE_ID)
             .build();
     }
-
 
     private SearchResponse getSearchResponse() throws IOException {
         String jsonResponse = stringFromResources(Path.of(SAMPLE_ELASTICSEARCH_RESPONSE_JSON));

--- a/search-resources-api/src/test/java/no/unit/nva/search/SearchHandlerTest.java
+++ b/search-resources-api/src/test/java/no/unit/nva/search/SearchHandlerTest.java
@@ -1,29 +1,5 @@
 package no.unit.nva.search;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import no.unit.nva.indexing.testutils.SearchResponseUtil;
-import no.unit.nva.search.restclients.IdentityClient;
-import no.unit.nva.search.restclients.responses.UserResponse;
-import no.unit.nva.testutils.HandlerRequestBuilder;
-import nva.commons.apigateway.GatewayResponse;
-import nva.commons.core.Environment;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
 import static java.net.HttpURLConnection.HTTP_OK;
 import static no.unit.nva.search.RequestUtil.DOMAIN_NAME;
 import static no.unit.nva.search.RequestUtil.PATH;
@@ -35,10 +11,37 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import no.unit.nva.indexing.testutils.SearchResponseUtil;
+import no.unit.nva.search.restclients.IdentityClient;
+import no.unit.nva.search.restclients.responses.UserResponse;
+import no.unit.nva.search.restclients.responses.UserResponse.ViewingScope;
+import no.unit.nva.testutils.HandlerRequestBuilder;
+import nva.commons.apigateway.GatewayResponse;
+import nva.commons.core.Environment;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SearchHandlerTest {
 
@@ -46,38 +49,28 @@ public class SearchHandlerTest {
     public static final String RESOURCE_ID = "bd0f0ba3-e17d-473c-b6d5-d97447b26332";
     public static final String MESSAGE = "message";
     public static final String INDEX = "index";
-    public static final String QUERY = "query";
-    public static final String WILDCARD = "*";
-    public static final String SAMPLE_PATH = "search";
-    public static final String SAMPLE_DOMAIN_NAME = "localhost";
-    public static final Map<String, Map<String, String>> SAMPLE_CLAIMS_WITH_FEIDE_ID = Map.of(
-            "claims", Map.of("custom:feideId", "user@localhost"));
-    public static final String AUTHORIZER = "authorizer";
+    public static final String SAMPLE_FEIDE_ID = "user@localhost";
+    public static final String VIEWING_SCOPE_QUERY_PARAMETER = "viewingScope";
 
     private IdentityClient identityClientMock;
-    private RestHighLevelClient restHighLevelClientMock;
     private SearchHandler handler;
-    private Context contextMock;
+    private Context context;
     private ByteArrayOutputStream outputStream;
+    private FakeRestHighLevelClientWrapper restHighLevelClientWrapper;
 
     @BeforeEach
-    void init() {
-        restHighLevelClientMock = mock(RestHighLevelClient.class);
-        RestHighLevelClientWrapper restHighLevelClientWrapper = new RestHighLevelClientWrapper(restHighLevelClientMock);
+    void init() throws IOException {
+        prepareSearchClientWithResponse();
         SearchClient searchClient = new SearchClient(restHighLevelClientWrapper);
-        identityClientMock = mock(IdentityClient.class);
+        setupFakeIdentityClient();
         handler = new SearchHandler(new Environment(), searchClient, identityClientMock);
-        contextMock = mock(Context.class);
+        context = mock(Context.class);
         outputStream = new ByteArrayOutputStream();
     }
 
     @Test
-    public void shouldReturnSearchResponseWithSearchHit() throws IOException {
-
-        prepareSearchClientWithResponse();
-        prepareIdentityClientWithResponse();
-
-        handler.handleRequest(getInputStream(), outputStream, contextMock);
+    void shouldReturnSearchResponseWithSearchHit() throws IOException {
+        handler.handleRequest(queryWithoutQueryParameters(), outputStream, context);
 
         GatewayResponse<String> response = GatewayResponse.fromOutputStream(outputStream);
 
@@ -88,7 +81,28 @@ public class SearchHandlerTest {
         assertThat(jsonNode, is(notNullValue()));
     }
 
-    private void prepareIdentityClientWithResponse() {
+    @Test
+    void shouldSendQueryOverridingDefaultViewingScopeWhenAnOrganizationIsSpecifiedInQueryParameter()
+        throws IOException {
+        final URI desiredOrgUri = randomUri();
+        handler.handleRequest(queryWithCustomOrganizationAsQueryParameter(desiredOrgUri), outputStream, context);
+        SearchRequest searchRequest = restHighLevelClientWrapper.getSearchRequest();
+        String queryDescription=searchRequest.buildDescription();
+
+        final var notExpectedDefaultViewingUris = identityClientMock.getUser(SAMPLE_FEIDE_ID)
+            .map(UserResponse::getViewingScope)
+            .map(ViewingScope::getIncludedUnits)
+            .orElseThrow();
+
+        assertThat(queryDescription, containsString(desiredOrgUri.toString()));
+
+        for(URI notExpectedUri:notExpectedDefaultViewingUris){
+            assertThat(queryDescription,not(containsString(notExpectedUri.toString())));
+        }
+    }
+
+    private void setupFakeIdentityClient() {
+        identityClientMock = mock(IdentityClient.class);
         when(identityClientMock.getUser(anyString())).thenReturn(getUserResponse());
     }
 
@@ -102,26 +116,29 @@ public class SearchHandlerTest {
     }
 
     private void prepareSearchClientWithResponse() throws IOException {
+        RestHighLevelClient restHighLevelClientMock = mock(RestHighLevelClient.class);
         when(restHighLevelClientMock.search(any(), any())).thenReturn(getSearchResponse());
+        restHighLevelClientWrapper = new FakeRestHighLevelClientWrapper(restHighLevelClientMock);
     }
 
-    private InputStream getInputStream() throws JsonProcessingException {
+    private InputStream queryWithoutQueryParameters() throws JsonProcessingException {
         return new HandlerRequestBuilder<Void>(objectMapperWithEmpty)
-                .withPathParameters(Map.of(INDEX, MESSAGE))
-                .withQueryParameters(Map.of(QUERY, WILDCARD))
-                .withRequestContext(getRequestContext())
-                .build();
+            .withPathParameters(Map.of(INDEX, MESSAGE))
+            .withFeideId(SAMPLE_FEIDE_ID)
+            .build();
     }
 
-    private ObjectNode getRequestContext() {
-        return objectMapperWithEmpty.convertValue(Map.of(
-                PATH, SAMPLE_PATH, DOMAIN_NAME, SAMPLE_DOMAIN_NAME, AUTHORIZER, SAMPLE_CLAIMS_WITH_FEIDE_ID),
-                ObjectNode.class);
+    private InputStream queryWithCustomOrganizationAsQueryParameter(URI desiredOrgUri) throws JsonProcessingException {
+        return new HandlerRequestBuilder<Void>(objectMapperWithEmpty)
+            .withPathParameters(Map.of(INDEX, MESSAGE))
+            .withQueryParameters(Map.of(VIEWING_SCOPE_QUERY_PARAMETER, desiredOrgUri.toString()))
+            .withFeideId(SAMPLE_FEIDE_ID)
+            .build();
     }
+
 
     private SearchResponse getSearchResponse() throws IOException {
         String jsonResponse = stringFromResources(Path.of(SAMPLE_ELASTICSEARCH_RESPONSE_JSON));
         return SearchResponseUtil.getSearchResponseFromJson(jsonResponse);
     }
-
 }


### PR DESCRIPTION
add a query parameter to the endpoint so that the following query is possible:
```
https://api.dev.nva.aws.unit.no/search/doirequests/search?viewingScope=https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0
```