### PR TITLE
remove index parameter from worklist

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -77,10 +77,6 @@ paths:
     get:
       description: TODO
       parameters:
-        - in: path
-          name: index
-          description: "Index for worklist items"
-          required: true
         - in: query
           name: viewingScope
           description: "List resources for this organization."


### PR DESCRIPTION
Index parameter is not required and not used by the /worklist endpoint