### PR TITLE
add subaggregations to search

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/constants/ApplicationConstants.java
+++ b/search-commons/src/main/java/no/unit/nva/search/constants/ApplicationConstants.java
@@ -2,12 +2,12 @@ package no.unit.nva.search.constants;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import java.util.Map;
-
 import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.search.models.AggregationDTO;
 import nva.commons.core.Environment;
 
 public final class ApplicationConstants {
+
     public static final String OPENSEARCH_ENDPOINT_INDEX = "resources";
     public static final String RESOURCES_INDEX = "resources";
     public static final String DOIREQUESTS_INDEX = "doirequests";
@@ -16,36 +16,41 @@ public final class ApplicationConstants {
 
     public static final String TICKETS_INDEX = "tickets";
 
-    public static final Map<String, String> AGGREGATIONS = Map.of(
-            "entityDescription.reference.publicationInstance.type",
-                "entityDescription.reference.publicationInstance.type.keyword",
-            "resourceOwner.owner",
-                "resourceOwner.owner.keyword",
-            "resourceOwner.ownerAffiliation",
-                "resourceOwner.ownerAffiliation.keyword",
-            "entityDescription.contributors.identity.name",
-                "entityDescription.contributors.identity.name.keyword"
+    public static final List<AggregationDTO> AGGREGATIONS = List.of(
+        new AggregationDTO("entityDescription.reference.publicationInstance.type",
+                           "entityDescription.reference.publicationInstance.type.keyword"),
+        new AggregationDTO("resourceOwner.owner",
+                           "resourceOwner.owner.keyword"),
+        new AggregationDTO("resourceOwner.ownerAffiliation",
+                           "resourceOwner.ownerAffiliation.keyword"),
+        new AggregationDTO("entityDescription.contributors.identity.name",
+                           "entityDescription.contributors.identity.name.keyword"),
+        new AggregationDTO("entityDescription.contributors.identity.name.keyword",
+                           "entityDescription.contributors.identity.name.keyword",
+                           new AggregationDTO(
+                               "entityDescription.contributors.affiliations.id.keyword",
+                               "entityDescription.contributors.affiliations.id.keyword"))
     );
 
     public static final List<String> TICKET_INDICES =
         List.of(DOIREQUESTS_INDEX, MESSAGES_INDEX, PUBLISHING_REQUESTS_INDEX);
 
     public static final List<String> ALL_INDICES = List.of(RESOURCES_INDEX, DOIREQUESTS_INDEX, MESSAGES_INDEX,
-            TICKETS_INDEX, PUBLISHING_REQUESTS_INDEX);
-    
+                                                           TICKETS_INDEX, PUBLISHING_REQUESTS_INDEX);
+
     public static final Environment ENVIRONMENT = new Environment();
 
     public static final String SEARCH_INFRASTRUCTURE_API_URI = readSearchInfrastructureApiUri();
 
     public static final String SEARCH_INFRASTRUCTURE_AUTH_URI = readSearchInfrastructureAuthUri();
-    
+
     public static final ObjectMapper objectMapperWithEmpty = JsonUtils.dtoObjectMapper;
     public static final ObjectMapper objectMapperNoEmpty = JsonUtils.dynamoObjectMapper;
-    
+
     private ApplicationConstants() {
-    
+
     }
-    
+
     private static String readSearchInfrastructureApiUri() {
         return ENVIRONMENT.readEnv("SEARCH_INFRASTRUCTURE_API_URI");
     }

--- a/search-commons/src/main/java/no/unit/nva/search/constants/ApplicationConstants.java
+++ b/search-commons/src/main/java/no/unit/nva/search/constants/ApplicationConstants.java
@@ -3,7 +3,7 @@ package no.unit.nva.search.constants;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import no.unit.nva.commons.json.JsonUtils;
-import no.unit.nva.search.models.AggregationDTO;
+import no.unit.nva.search.models.AggregationDto;
 import nva.commons.core.Environment;
 
 public final class ApplicationConstants {
@@ -16,18 +16,18 @@ public final class ApplicationConstants {
 
     public static final String TICKETS_INDEX = "tickets";
 
-    public static final List<AggregationDTO> AGGREGATIONS = List.of(
-        new AggregationDTO("entityDescription.reference.publicationInstance.type",
+    public static final List<AggregationDto> AGGREGATIONS = List.of(
+        new AggregationDto("entityDescription.reference.publicationInstance.type",
                            "entityDescription.reference.publicationInstance.type.keyword"),
-        new AggregationDTO("resourceOwner.owner",
+        new AggregationDto("resourceOwner.owner",
                            "resourceOwner.owner.keyword"),
-        new AggregationDTO("resourceOwner.ownerAffiliation",
+        new AggregationDto("resourceOwner.ownerAffiliation",
                            "resourceOwner.ownerAffiliation.keyword"),
-        new AggregationDTO("entityDescription.contributors.identity.name",
+        new AggregationDto("entityDescription.contributors.identity.name",
                            "entityDescription.contributors.identity.name.keyword"),
-        new AggregationDTO("entityDescription.contributors.identity.name.keyword",
-                           "entityDescription.contributors.identity.name.keyword",
-                           new AggregationDTO(
+        new AggregationDto("entityDescription.contributors.affiliations.partOf.id.keyword",
+                           "entityDescription.contributors.affiliations.partOf.id.keyword",
+                           new AggregationDto(
                                "entityDescription.contributors.affiliations.id.keyword",
                                "entityDescription.contributors.affiliations.id.keyword"))
     );

--- a/search-commons/src/main/java/no/unit/nva/search/models/AggregationDTO.java
+++ b/search-commons/src/main/java/no/unit/nva/search/models/AggregationDTO.java
@@ -1,0 +1,47 @@
+package no.unit.nva.search.models;
+
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+
+public class AggregationDTO {
+
+    public String term;
+    public String field;
+    public AggregationDTO subAggregation;
+    public int aggregationBucketAmount = 100;
+
+    public AggregationDTO(String term, String field) {
+        this.term = term;
+        this.field = field;
+    }
+
+    public AggregationDTO(String term, String field, AggregationDTO subAggregation) {
+        this.term = term;
+        this.field = field;
+        this.subAggregation = subAggregation;
+    }
+
+    public AggregationDTO(String term, String field, AggregationDTO subAggregation, int aggregationBucketAmount) {
+        this.term = term;
+        this.field = field;
+        this.subAggregation = subAggregation;
+        this.aggregationBucketAmount = aggregationBucketAmount;
+    }
+
+    public TermsAggregationBuilder toAggregationBuilder() {
+        return buildAggregations(this);
+    }
+
+    private static TermsAggregationBuilder buildAggregations(AggregationDTO aggDTO) {
+        var aggregationBuilder = AggregationBuilders
+            .terms(aggDTO.term)
+            .field(aggDTO.field)
+            .size(aggDTO.aggregationBucketAmount);
+
+        if (aggDTO.subAggregation != null) {
+            aggregationBuilder.subAggregation(buildAggregations(aggDTO.subAggregation));
+        }
+
+        return aggregationBuilder;
+    }
+}

--- a/search-commons/src/main/java/no/unit/nva/search/models/AggregationDto.java
+++ b/search-commons/src/main/java/no/unit/nva/search/models/AggregationDto.java
@@ -3,28 +3,25 @@ package no.unit.nva.search.models;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 
-public class AggregationDTO {
+public class AggregationDto {
 
     public String term;
     public String field;
-    public AggregationDTO subAggregation;
+    public AggregationDto subAggregation;
     public int aggregationBucketAmount = 100;
 
-    public AggregationDTO(String term, String field) {
+    public AggregationDto(String term, String field) {
         this.term = term;
         this.field = field;
     }
 
-    public AggregationDTO(String term, String field, AggregationDTO subAggregation) {
+    public AggregationDto(String term, String field, AggregationDto subAggregation) {
         this.term = term;
         this.field = field;
         this.subAggregation = subAggregation;
     }
 
-    public AggregationDTO(String term, String field, AggregationDTO subAggregation, int aggregationBucketAmount) {
-        this.term = term;
-        this.field = field;
-        this.subAggregation = subAggregation;
+    public void setAggregationBucketAmount(int aggregationBucketAmount) {
         this.aggregationBucketAmount = aggregationBucketAmount;
     }
 
@@ -32,7 +29,7 @@ public class AggregationDTO {
         return buildAggregations(this);
     }
 
-    private static TermsAggregationBuilder buildAggregations(AggregationDTO aggDTO) {
+    private static TermsAggregationBuilder buildAggregations(AggregationDto aggDTO) {
         var aggregationBuilder = AggregationBuilders
             .terms(aggDTO.term)
             .field(aggDTO.field)

--- a/search-commons/src/main/java/no/unit/nva/search/models/SearchDocumentsQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/models/SearchDocumentsQuery.java
@@ -17,7 +17,7 @@ public class SearchDocumentsQuery {
     private final String orderBy;
     private final SortOrder sortOrder;
     private final URI requestUri;
-    private final List<AggregationDTO> aggregations;
+    private final List<AggregationDto> aggregations;
 
     public SearchDocumentsQuery(String searchTerm,
                                 int results,
@@ -25,7 +25,7 @@ public class SearchDocumentsQuery {
                                 String orderBy,
                                 SortOrder sortOrder,
                                 URI requestUri,
-                                List<AggregationDTO> aggregations) {
+                                List<AggregationDto> aggregations) {
         this.searchTerm = searchTerm;
         this.results = results;
         this.from = from;

--- a/search-commons/src/main/java/no/unit/nva/search/models/SearchDocumentsQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/models/SearchDocumentsQuery.java
@@ -1,12 +1,9 @@
 package no.unit.nva.search.models;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Objects.nonNull;
 import java.net.URI;
-import java.util.Map;
+import java.util.List;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
@@ -20,16 +17,7 @@ public class SearchDocumentsQuery {
     private final String orderBy;
     private final SortOrder sortOrder;
     private final URI requestUri;
-    private Map<String, String> aggregationFields;
-    private int aggregationBucketAmount = 100;
-
-    public void setAggregationBucketAmount(int aggregationBucketAmount) {
-        this.aggregationBucketAmount = aggregationBucketAmount;
-    }
-
-    public void setAggregationFields(Map<String, String> aggregationFields) {
-        this.aggregationFields = aggregationFields;
-    }
+    private final List<AggregationDTO> aggregations;
 
     public SearchDocumentsQuery(String searchTerm,
                                 int results,
@@ -37,14 +25,14 @@ public class SearchDocumentsQuery {
                                 String orderBy,
                                 SortOrder sortOrder,
                                 URI requestUri,
-                                Map<String, String> aggregationFields) {
+                                List<AggregationDTO> aggregations) {
         this.searchTerm = searchTerm;
         this.results = results;
         this.from = from;
         this.orderBy = orderBy;
         this.sortOrder = sortOrder;
         this.requestUri = requestUri;
-        this.aggregationFields = nonNull(aggregationFields) ? aggregationFields : emptyMap();
+        this.aggregations = aggregations;
     }
 
     public String getSearchTerm() {
@@ -62,26 +50,19 @@ public class SearchDocumentsQuery {
     private SearchSourceBuilder toSearchSourceBuilder() {
 
         var sourceBuilder = new SearchSourceBuilder()
-                .query(QueryBuilders.queryStringQuery(searchTerm))
-                .sort(SortBuilders.fieldSort(orderBy).unmappedType(STRING).order(sortOrder))
-                .from(from)
-                .size(results);
+            .query(QueryBuilders.queryStringQuery(searchTerm))
+            .sort(SortBuilders.fieldSort(orderBy).unmappedType(STRING).order(sortOrder))
+            .from(from)
+            .size(results);
 
-        if (aggregationFields != null) {
-            addAggregationToSourceBuilder(sourceBuilder);
+        if (aggregations != null) {
+            addAggregations(sourceBuilder);
         }
 
         return sourceBuilder;
     }
 
-    private void addAggregationToSourceBuilder(SearchSourceBuilder sourceBuilder) {
-        aggregationFields.forEach((term, field) ->
-                sourceBuilder.aggregation(
-                        AggregationBuilders
-                                .terms(term)
-                                .field(field)
-                                .size(aggregationBucketAmount)
-                )
-        );
+    private void addAggregations(SearchSourceBuilder sourceBuilder) {
+        aggregations.forEach(aggDTO -> sourceBuilder.aggregation(aggDTO.toAggregationBuilder()));
     }
 }

--- a/search-commons/src/test/java/no/unit/nva/search/OpensearchTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/OpensearchTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import no.unit.nva.identifiers.SortableIdentifier;
-import no.unit.nva.search.models.AggregationDTO;
+import no.unit.nva.search.models.AggregationDto;
 import no.unit.nva.search.models.EventConsumptionAttributes;
 import no.unit.nva.search.models.IndexDocument;
 import no.unit.nva.search.models.SearchDocumentsQuery;
@@ -49,8 +49,8 @@ public class OpensearchTest {
     private static final String SAMPLE_ORDERBY = "orderByField";
     private static final URI SAMPLE_REQUEST_URI = randomUri();
     public static final URI INCLUDED_ORGANIZATION_ID = randomUri();
-    private static final List<AggregationDTO> SAMPLE_AGGREGATIONS = List.of(
-        new AggregationDTO(randomString(), randomString()));
+    private static final List<AggregationDto> SAMPLE_AGGREGATIONS = List.of(
+        new AggregationDto(randomString(), randomString()));
     public static final URI EXCLUDED_ORGANIZATION_ID = randomUri();
     public static final int ZERO_HITS_BECAUSE_VIEWING_SCOPE_IS_EMPTY = 0;
     public static final int TWO_HITS_BECAUSE_MATCH_ON_BOTH_INCLUDED_UNITS = 2;
@@ -287,9 +287,9 @@ public class OpensearchTest {
             crateSampleIndexDocument(indexName, "sample_publishing_request_of_published_publication.json"));
         Thread.sleep(DELAY_AFTER_INDEXING);
 
-        var aggregationDto = new AggregationDTO(
+        var aggregationDto = new AggregationDto(
             "contributors", "publication.contributors.identity.name.keyword",
-            new AggregationDTO("affiliations", "publication.contributors.affiliations.id.keyword")
+            new AggregationDto("affiliations", "publication.contributors.affiliations.id.keyword")
         );
 
         SearchDocumentsQuery query = new SearchDocumentsQuery(
@@ -327,10 +327,9 @@ public class OpensearchTest {
             crateSampleIndexDocument(indexName, "sample_publishing_request_of_published_publication.json"));
         Thread.sleep(DELAY_AFTER_INDEXING);
 
-        var aggregationDto = new AggregationDTO("publication.status",
-                                                "publication.status.keyword",
-                                                null,
-                                                1);
+        var aggregationDto = new AggregationDto("publication.status",
+                                                "publication.status.keyword");
+        aggregationDto.setAggregationBucketAmount(1);
 
         SearchDocumentsQuery query = new SearchDocumentsQuery(
             "*",

--- a/search-commons/src/test/java/no/unit/nva/search/SearchClientTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/SearchClientTest.java
@@ -38,7 +38,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import no.unit.nva.search.models.AggregationDTO;
+import no.unit.nva.search.models.AggregationDto;
 import no.unit.nva.search.models.SearchDocumentsQuery;
 import no.unit.nva.search.models.SearchResponseDto;
 import no.unit.nva.search.models.UsernamePasswordWrapper;
@@ -71,8 +71,8 @@ class SearchClientTest {
     private static final String OPENSEARCH_SAMPLE_RESPONSE_FILE = "sample_opensearch_response.json";
     private static final int OPENSEARCH_ACTUAL_SAMPLE_NUMBER_OF_RESULTS = 2;
     private static final URI SAMPLE_REQUEST_URI = randomUri();
-    private static final List<AggregationDTO> SAMPLE_AGGREGATIONS = List.of(
-        new AggregationDTO(randomString(), randomString()));
+    private static final List<AggregationDto> SAMPLE_AGGREGATIONS = List.of(
+        new AggregationDto(randomString(), randomString()));
 
     SearchResponse defaultSearchResponse = mock(SearchResponse.class);
 
@@ -273,16 +273,16 @@ class SearchClientTest {
         };
 
         var nestedAggregationDTOs = List.of(
-            new AggregationDTO(
+            new AggregationDto(
                 randomString(),
                 randomString(),
-                new AggregationDTO(
+                new AggregationDto(
                     randomString(),
                     randomString(),
                     SAMPLE_AGGREGATIONS.get(0)
                 )
             ),
-            new AggregationDTO(
+            new AggregationDto(
                 randomString(),
                 randomString()
             )
@@ -307,7 +307,7 @@ class SearchClientTest {
         nestedAggregationDTOs.forEach(aggDTO -> assertAggregationHasField(actualAggregation, aggDTO));
     }
 
-    private void assertAggregationHasField(JsonNode json, AggregationDTO aggDto) {
+    private void assertAggregationHasField(JsonNode json, AggregationDto aggDto) {
         var actualField = json.at("/" + aggDto.term + "/terms/field").asText();
         assertThat(actualField, is(equalTo(aggDto.field)));
 

--- a/search-commons/src/test/resources/sample_publishing_request_of_draft_publication.json
+++ b/search-commons/src/test/resources/sample_publishing_request_of_draft_publication.json
@@ -24,10 +24,16 @@
         "type": "Contributor",
         "identity": {
           "type": "Identity",
-          "name": "Orestis Gkorgkas",
+          "name": "Hans Nordmann",
           "nameType": "Personal"
         },
-        "affiliations": [],
+        "affiliations": [
+          {
+            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/185.27.82.0",
+            "type": "Organization",
+            "labels": {}
+          }
+        ],
         "role": "Creator",
         "sequence": 1,
         "correspondingAuthor": false

--- a/search-commons/src/test/resources/sample_publishing_request_of_published_publication.json
+++ b/search-commons/src/test/resources/sample_publishing_request_of_published_publication.json
@@ -27,7 +27,13 @@
           "name": "Orestis Gkorgkas",
           "nameType": "Personal"
         },
-        "affiliations": [],
+        "affiliations": [
+          {
+            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.4.0.0",
+            "type": "Organization",
+            "labels": {}
+          }
+        ],
         "role": "Creator",
         "sequence": 1,
         "correspondingAuthor": false

--- a/search-resources-api/src/main/java/no/unit/nva/search/RequestUtil.java
+++ b/search-resources-api/src/main/java/no/unit/nva/search/RequestUtil.java
@@ -1,15 +1,14 @@
 package no.unit.nva.search;
 
+import static nva.commons.core.attempt.Try.attempt;
+import java.net.URI;
+import java.util.List;
+import no.unit.nva.search.models.AggregationDTO;
 import no.unit.nva.search.models.SearchDocumentsQuery;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UriWrapper;
 import org.opensearch.search.sort.SortOrder;
-
-import java.net.URI;
-import java.util.Map;
-
-import static nva.commons.core.attempt.Try.attempt;
 
 @JacocoGenerated
 public class RequestUtil {
@@ -51,7 +50,7 @@ public class RequestUtil {
     }
 
     public static SortOrder getSortOrder(RequestInfo requestInfo) {
-        return SortOrder.fromString(requestInfo.getQueryParameters().getOrDefault(SORTORDER_KEY, DEFAULT_SORT_ORDER));
+        return SortOrder.valueOf(requestInfo.getQueryParameters().getOrDefault(SORTORDER_KEY, DEFAULT_SORT_ORDER));
     }
 
     public static URI getRequestUri(RequestInfo requestInfo) {
@@ -62,26 +61,26 @@ public class RequestUtil {
 
     public static String getRequestPath(RequestInfo requestInfo) {
         return attempt(() -> requestInfo.getRequestContext()
-                .get(PATH).asText())
-                .orElseThrow();
+            .get(PATH).asText())
+            .orElseThrow();
     }
 
     public static String getRequestDomainName(RequestInfo requestInfo) {
         return attempt(() -> requestInfo.getRequestContext()
-                .get(DOMAIN_NAME).asText())
-                .orElseThrow();
+            .get(DOMAIN_NAME).asText())
+            .orElseThrow();
     }
 
-    public static SearchDocumentsQuery toQuery(RequestInfo requestInfo, Map<String, String> aggregationFields) {
+    public static SearchDocumentsQuery toQuery(RequestInfo requestInfo,
+                                               List<AggregationDTO> aggregations) {
         return new SearchDocumentsQuery(
-                getSearchTerm(requestInfo),
-                getResults(requestInfo),
-                getFrom(requestInfo),
-                getOrderBy(requestInfo),
-                getSortOrder(requestInfo),
-                getRequestUri(requestInfo),
-                aggregationFields
+            getSearchTerm(requestInfo),
+            getResults(requestInfo),
+            getFrom(requestInfo),
+            getOrderBy(requestInfo),
+            getSortOrder(requestInfo),
+            getRequestUri(requestInfo),
+            aggregations
         );
     }
-
 }

--- a/search-resources-api/src/main/java/no/unit/nva/search/RequestUtil.java
+++ b/search-resources-api/src/main/java/no/unit/nva/search/RequestUtil.java
@@ -3,7 +3,7 @@ package no.unit.nva.search;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
 import java.util.List;
-import no.unit.nva.search.models.AggregationDTO;
+import no.unit.nva.search.models.AggregationDto;
 import no.unit.nva.search.models.SearchDocumentsQuery;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.core.JacocoGenerated;
@@ -72,7 +72,7 @@ public class RequestUtil {
     }
 
     public static SearchDocumentsQuery toQuery(RequestInfo requestInfo,
-                                               List<AggregationDTO> aggregations) {
+                                               List<AggregationDto> aggregations) {
         return new SearchDocumentsQuery(
             getSearchTerm(requestInfo),
             getResults(requestInfo),

--- a/search-resources-api/src/main/java/no/unit/nva/search/SearchResourcesApiHandler.java
+++ b/search-resources-api/src/main/java/no/unit/nva/search/SearchResourcesApiHandler.java
@@ -1,5 +1,10 @@
 package no.unit.nva.search;
 
+import static no.unit.nva.search.RequestUtil.toQuery;
+import static no.unit.nva.search.SearchClient.defaultSearchClient;
+import static no.unit.nva.search.constants.ApplicationConstants.AGGREGATIONS;
+import static no.unit.nva.search.constants.ApplicationConstants.OPENSEARCH_ENDPOINT_INDEX;
+import static no.unit.nva.search.constants.ApplicationConstants.objectMapperWithEmpty;
 import com.amazonaws.services.lambda.runtime.Context;
 import no.unit.nva.search.models.SearchResponseDto;
 import nva.commons.apigateway.ApiGatewayHandler;
@@ -9,12 +14,6 @@ import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import org.apache.http.HttpStatus;
-
-import static no.unit.nva.search.RequestUtil.toQuery;
-import static no.unit.nva.search.SearchClient.defaultSearchClient;
-import static no.unit.nva.search.constants.ApplicationConstants.AGGREGATIONS;
-import static no.unit.nva.search.constants.ApplicationConstants.OPENSEARCH_ENDPOINT_INDEX;
-import static no.unit.nva.search.constants.ApplicationConstants.objectMapperWithEmpty;
 
 public class SearchResourcesApiHandler extends ApiGatewayHandler<Void, SearchResponseDto> {
 
@@ -60,5 +59,4 @@ public class SearchResourcesApiHandler extends ApiGatewayHandler<Void, SearchRes
     protected Integer getSuccessStatusCode(Void input, SearchResponseDto output) {
         return HttpStatus.SC_OK;
     }
-
 }


### PR DESCRIPTION
Legger til muligheten til å bruke generelle subaggregeringer og en basic fasett som vil gi ut foreldreNoden til Institusjonen/fakultetet søket treffer på. 
F.eks.: "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.10.0" er et treff, da får man 
```
{
    "key": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0",
    "doc_count": 1,
    "current": {
        "doc_count_error_upper_bound": 0,
        "sum_other_doc_count": 0,
        "buckets": [
            {
                "key": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.10.0",
                "doc_count": 1
            }
        ]
    }
}
```