### PR TITLE
Nested query

### DIFF
--- a/indexing-handlers/src/main/resources/resources_mapping.json
+++ b/indexing-handlers/src/main/resources/resources_mapping.json
@@ -35,9 +35,11 @@
         },
         "reference": {
           "type": "nested",
+          "include_in_parent": true,
           "properties": {
             "publicationInstance": {
               "type": "nested",
+              "include_in_parent": true,
               "properties": {
                 "type": {
                   "type": "keyword"

--- a/indexing-handlers/src/main/resources/resources_mapping.json
+++ b/indexing-handlers/src/main/resources/resources_mapping.json
@@ -13,17 +13,33 @@
     },
     "entityDescription": {
       "type": "nested",
+      "include_in_parent": true,
       "properties": {
         "contributors": {
           "type": "nested",
+          "include_in_parent": true,
           "properties": {
             "identity": {
               "type": "nested",
+              "include_in_parent": true,
               "properties": {
                 "id": {
                   "type": "keyword"
                 },
                 "name": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "reference": {
+          "type": "nested",
+          "properties": {
+            "publicationInstance": {
+              "type": "nested",
+              "properties": {
+                "type": {
                   "type": "keyword"
                 }
               }

--- a/search-commons/src/test/resources/test_resources_mappings.json
+++ b/search-commons/src/test/resources/test_resources_mappings.json
@@ -35,9 +35,11 @@
         },
         "reference": {
           "type": "nested",
+          "include_in_parent": true,
           "properties": {
             "publicationInstance": {
               "type": "nested",
+              "include_in_parent": true,
               "properties": {
                 "type": {
                   "type": "keyword"

--- a/search-commons/src/test/resources/test_resources_mappings.json
+++ b/search-commons/src/test/resources/test_resources_mappings.json
@@ -13,17 +13,33 @@
     },
     "entityDescription": {
       "type": "nested",
+      "include_in_parent": true,
       "properties": {
         "contributors": {
           "type": "nested",
+          "include_in_parent": true,
           "properties": {
             "identity": {
               "type": "nested",
+              "include_in_parent": true,
               "properties": {
                 "id": {
                   "type": "keyword"
                 },
                 "name": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "reference": {
+          "type": "nested",
+          "properties": {
+            "publicationInstance": {
+              "type": "nested",
+              "properties": {
+                "type": {
                   "type": "keyword"
                 }
               }


### PR DESCRIPTION
Since publicationInstance and contributors are child objects of entityDescription, this aggregation is more correct.
(It is identical the aggregation we created in openSearch dashbord today)

In addition "include_in_parent" field in mappings makes in possible to query on contributor the way we want it.

This makes it possible to query on entityDescription.contributors.identity.id like this:

https://api.dev.nva.aws.unit.no/search/resourcesquery=
entityDescription.contributors.identity.id:"https://api.dev.nva.aws.unit.no/cristin/person/1137379"


Frontend may need minor changes for publicationInstance.type aggregation