### PR TITLE
Np 45094 take in use search after

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/SearchClient.java
+++ b/search-commons/src/main/java/no/unit/nva/search/SearchClient.java
@@ -17,9 +17,12 @@ import nva.commons.secrets.SecretsReader;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SearchClient extends AuthenticatedOpenSearchClientWrapper {
 
+    private static final Logger logger = LoggerFactory.getLogger(SearchClient.class);
     public static final String NO_RESPONSE_FROM_INDEX = "No response from index";
     public static final String ORGANIZATION_IDS = "organizationIds";
     public static final String PUBLICATION_STATUS = "publication.status";
@@ -125,6 +128,7 @@ public class SearchClient extends AuthenticatedOpenSearchClientWrapper {
     private SearchResponseDto doSearch(SearchRequest searchRequest, URI requestUri, String searchTerm)
         throws IOException {
         var searchResponse = openSearchClient.search(searchRequest, getRequestOptions());
+        logger.info("Original search response: {}", searchResponse.toString());
         var id = createIdWithQuery(requestUri, searchTerm);
         return fromSearchResponse(searchResponse, id);
     }

--- a/search-commons/src/main/java/no/unit/nva/search/models/SearchDocumentsQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/models/SearchDocumentsQuery.java
@@ -1,5 +1,6 @@
 package no.unit.nva.search.models;
 
+import static java.util.Objects.nonNull;
 import java.net.URI;
 import java.util.List;
 import org.opensearch.action.search.SearchRequest;
@@ -19,10 +20,11 @@ public class SearchDocumentsQuery {
     private final String orderBy;
     private final SortOrder sortOrder;
     private final URI requestUri;
+    private final String searchAfter;
     private final List<AbstractAggregationBuilder<? extends AbstractAggregationBuilder<?>>> aggregations;
 
     public SearchDocumentsQuery(String searchTerm, int results, int from, String orderBy, SortOrder sortOrder,
-                                URI requestUri,
+                                URI requestUri, String searchAfter,
                                 List<AbstractAggregationBuilder<? extends AbstractAggregationBuilder<?>>> aggregations) {
         this.searchTerm = searchTerm;
         this.results = results;
@@ -30,6 +32,7 @@ public class SearchDocumentsQuery {
         this.orderBy = orderBy;
         this.sortOrder = sortOrder;
         this.requestUri = requestUri;
+        this.searchAfter = searchAfter;
         this.aggregations = aggregations;
     }
 
@@ -73,6 +76,10 @@ public class SearchDocumentsQuery {
 
         if (aggregations != null) {
             addAggregations(sourceBuilder);
+        }
+
+        if(nonNull(searchAfter)) {
+            sourceBuilder.searchAfter(new String[]{searchAfter});
         }
 
         return sourceBuilder;

--- a/search-commons/src/test/java/no/unit/nva/search/OpensearchTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/OpensearchTest.java
@@ -488,6 +488,7 @@ public class OpensearchTest {
                 SAMPLE_ORDERBY,
                 DESC,
                 SAMPLE_REQUEST_URI,
+                null,
                 aggregations
             );
         }

--- a/search-commons/src/test/java/no/unit/nva/search/SearchClientTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/SearchClientTest.java
@@ -437,6 +437,7 @@ class SearchClientTest {
                                         SAMPLE_ORDERBY,
                                         DESC,
                                         SAMPLE_REQUEST_URI,
+                                        null,
                                         SAMPLE_AGGREGATIONS);
     }
 

--- a/search-resources-api/src/main/java/no/unit/nva/search/RequestUtil.java
+++ b/search-resources-api/src/main/java/no/unit/nva/search/RequestUtil.java
@@ -31,7 +31,7 @@ public class RequestUtil {
     public static final String DOMAIN_NAME = "domainName";
     public static final String HTTPS = "https";
     public static final Environment ENVIRONMENT = new Environment();
-    public static final String SEARCH_AFTER = "search-after";
+    public static final String SEARCH_AFTER = "searchAfter";
 
     /**
      * Get searchTerm from request query parameters.
@@ -44,7 +44,8 @@ public class RequestUtil {
     }
 
     public static String getSearchAfter(RequestInfo requestInfo) {
-        return requestInfo.getQueryParameters().getOrDefault(SEARCH_AFTER, SEARCH_ALL_PUBLICATIONS_DEFAULT_QUERY);
+        return requestInfo.getQueryParameters().getOrDefault(SEARCH_AFTER, null);
+
     }
 
     public static int getResults(RequestInfo requestInfo) {
@@ -95,7 +96,7 @@ public class RequestUtil {
             getOrderBy(requestInfo),
             getSortOrder(requestInfo),
             getRequestUri(requestInfo),
-
+            getSearchAfter(requestInfo),
             aggregations
         );
     }
@@ -110,6 +111,7 @@ public class RequestUtil {
             getOrderBy(requestInfo),
             getSortOrder(requestInfo),
             getRequestUri(requestInfo),
+            getSearchAfter(requestInfo),
             aggregations
         );
     }
@@ -124,6 +126,7 @@ public class RequestUtil {
             getOrderBy(requestInfo),
             getSortOrder(requestInfo),
             getRequestUri(requestInfo),
+            getSearchAfter(requestInfo),
             aggregations
         );
     }

--- a/search-resources-api/src/main/java/no/unit/nva/search/RequestUtil.java
+++ b/search-resources-api/src/main/java/no/unit/nva/search/RequestUtil.java
@@ -31,6 +31,7 @@ public class RequestUtil {
     public static final String DOMAIN_NAME = "domainName";
     public static final String HTTPS = "https";
     public static final Environment ENVIRONMENT = new Environment();
+    public static final String SEARCH_AFTER = "search-after";
 
     /**
      * Get searchTerm from request query parameters.
@@ -40,6 +41,10 @@ public class RequestUtil {
      */
     public static String getSearchTerm(RequestInfo requestInfo) {
         return requestInfo.getQueryParameters().getOrDefault(SEARCH_TERM_KEY, SEARCH_ALL_PUBLICATIONS_DEFAULT_QUERY);
+    }
+
+    public static String getSearchAfter(RequestInfo requestInfo) {
+        return requestInfo.getQueryParameters().getOrDefault(SEARCH_AFTER, SEARCH_ALL_PUBLICATIONS_DEFAULT_QUERY);
     }
 
     public static int getResults(RequestInfo requestInfo) {
@@ -90,6 +95,7 @@ public class RequestUtil {
             getOrderBy(requestInfo),
             getSortOrder(requestInfo),
             getRequestUri(requestInfo),
+
             aggregations
         );
     }

--- a/search-resources-api/src/test/resources/scratch.json
+++ b/search-resources-api/src/test/resources/scratch.json
@@ -1,0 +1,5363 @@
+{
+  "took": 767,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 74495,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources",
+        "_id": "018925500896-9cd6cfd1-114b-4279-b472-0858e0dfc3de",
+        "_score": null,
+        "_source": {
+          "type": "Publication",
+          "publicationContextUris": [],
+          "@context": {
+            "@vocab": "https://nva.sikt.no/ontology/publication#",
+            "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+            "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+            "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+            "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+            "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+            "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+            "Film": "https://nva.sikt.no/ontology/publication#Film",
+            "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+            "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+            "source": {
+              "@type": "@id"
+            },
+            "approvedBy": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+              },
+              "@type": "@vocab"
+            },
+            "activeFrom": {
+              "@type": "xsd:dateTime"
+            },
+            "activeTo": {
+              "@type": "xsd:dateTime"
+            },
+            "additionalIdentifiers": {
+              "@container": "@set",
+              "@id": "additionalIdentifier"
+            },
+            "affiliations": {
+              "@container": "@set",
+              "@id": "affiliation"
+            },
+            "alternativeTitles": {
+              "@container": "@language",
+              "@id": "alternativeTitle"
+            },
+            "approvals": {
+              "@container": "@set",
+              "@id": "approval"
+            },
+            "approvalStatus": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "architectureOutput": {
+              "@container": "@set",
+              "@id": "architectureOutput"
+            },
+            "associatedArtifacts": {
+              "@container": "@set",
+              "@id": "associatedArtifact"
+            },
+            "compliesWith": {
+              "@container": "@set",
+              "@id": "compliesWith"
+            },
+            "concertProgramme": {
+              "@container": "@set",
+              "@id": "concertProgramme"
+            },
+            "contributors": {
+              "@container": "@set",
+              "@id": "contributor"
+            },
+            "createdDate": {
+              "@type": "xsd:dateTime"
+            },
+            "doi": {
+              "@type": "@id"
+            },
+            "embargoDate": {
+              "@type": "xsd:dateTime"
+            },
+            "from": {
+              "@type": "xsd:dateTime"
+            },
+            "fundings": {
+              "@container": "@set",
+              "@id": "funding"
+            },
+            "handle": {
+              "@type": "@id"
+            },
+            "id": "@id",
+            "indexedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "isbnList": {
+              "@container": "@set",
+              "@id": "isbn"
+            },
+            "labels": {
+              "@container": "@language",
+              "@id": "label"
+            },
+            "language": {
+              "@type": "@id"
+            },
+            "link": {
+              "@type": "@id"
+            },
+            "manifestations": {
+              "@container": "@set",
+              "@id": "manifestation"
+            },
+            "metadataSource": {
+              "@type": "@id"
+            },
+            "modifiedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "musicalWorks": {
+              "@container": "@set",
+              "@id": "musicalWork"
+            },
+            "nameType": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "outputs": {
+              "@container": "@set",
+              "@id": "output"
+            },
+            "ownerAffiliation": {
+              "@type": "@id"
+            },
+            "projects": {
+              "@container": "@set",
+              "@id": "project"
+            },
+            "publishedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "referencedBy": {
+              "@container": "@set",
+              "@id": "referencedBy"
+            },
+            "related": {
+              "@container": "@set",
+              "@id": "related"
+            },
+            "status": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "subjects": {
+              "@container": "@set",
+              "@id": "subject",
+              "@type": "@id"
+            },
+            "tags": {
+              "@container": "@set",
+              "@id": "tag"
+            },
+            "to": {
+              "@type": "xsd:dateTime"
+            },
+            "trackList": {
+              "@container": "@set",
+              "@id": "trackList"
+            },
+            "type": "@type",
+            "venues": {
+              "@container": "@set",
+              "@id": "venue"
+            },
+            "nviType": {
+              "@type": "@vocab",
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              }
+            },
+            "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+            "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+            "publicationContextUris": {
+              "@container": "@set"
+            }
+          },
+          "id": "https://api.dev.nva.aws.unit.no/publication/018925500896-9cd6cfd1-114b-4279-b472-0858e0dfc3de",
+          "additionalIdentifiers": [
+            {
+              "type": "AdditionalIdentifier",
+              "sourceName": "Cristin",
+              "value": "1212331"
+            }
+          ],
+          "associatedArtifacts": [
+            {
+              "type": "PublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "b1e334c5-4f37-4ae6-8f2f-da08a47eda2c",
+              "mimeType": "application/pdf",
+              "name": "Master+Thesis+Florian+Eggers+Final.pdf",
+              "publishedDate": "2023-07-05T09:09:09.392922Z",
+              "publisherAuthority": false,
+              "size": 24135330,
+              "visibleForNonOwner": true
+            }
+          ],
+          "createdDate": "2015-01-30T10:12:29Z",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "abstract": "The present thesis provides strong indications for metapopulation dynamics occurring in Atlantic herring (Clupea harengus) along the Norwegian south coast. The evidence stems from analyses of population structure, growth, maturation, spawning time and migration at three different scales. Firstly, comparisons between three oceanic areas (southern and northern North Sea and Skagerrak/Kattegat), two coastal areas (east and west coast of southern Norway) and one local area (Landvikvannet and connected fjords) using historic data from 1970–2012. Secondly, a detailed study of the biological dynamics in the local area over the spawning season 2012. Thirdly, a study of individual migration behavior of tagged herring using acoustic transmitters in the local area over the spawning season 2012. The historical data demonstrated intra- and inter-annual stability in population structure and growth in the southern and northern North Sea. However, in Skagerrak/Kattegat as well as in the coastal and local areas it was highly dynamic. Moreover, the data on maturation and spawning time demonstrated very little overlap between the oceanic areas and the coastal ones, whereas spawning time overlapped clearly between herring diverging phenotypically from the west coast, east coast and in the local area, indicating that mixing of populations during spawning activities potentially could have happened. When this was studied in more details with the intensive biological sampling regime in the local area of Landvik and connected fjords during the spring 2012, data on otolith characteristics, vertebral counts and growth indicated the mixed presence of three different herring types during the spawning period. Herring caught inside Landvikvannet (ILV) had significant lower mean vertebral counts (VS) and lower growth than herring caught outside Landvikvannet in the connected fjords (OLV). Migratory Norwegian spring spawners (NSS) arrived early in the season with peak abundance in mid-March, and they could be identified through otolith characteristics, higher growth and VS (above 57.0) than the other two groups in the local area. While the growth and VS of NSS did not differ significantly within the spawning season, they decreased for ILV and OLV herring, suggesting a mixture of two components changing with time in both areas. The data indicated that one component with relatively fast growth and medium VS between 56.5 and 56.9 appeared early in the season already at the onset of sampling in February and stayed there the whole period. In addition, there was a slow growing component with low VS (below 56.0), similar to historic observations of ILV herring in May, which did not appear early in the season, peaking in May. Despite the different peaks of abundance between the three suggested components, there was a clear overlap in spawning stages. Acoustic telemetry of tagged herring also demonstrated behavioral differences within the local area, which support the conclusion of mixing herring populations in the area. While some herring left the study area immediately, others stayed for a while, migrated up and down in the connected fjords or even entered Landvikvannet. Most migrations took place during the evening and night. Additionally some herring were detected in another acoustic monitoring system 20 km to the north of the study system 2 to 35 days after leaving the area, demonstrating along-coast migrations at different speeds. Finally, relevant historical environmental data series and new environmental data collected during the 2012 spawning season in Landvik and connected fjords were analyzed in relation to the observed herring dynamics at the three different scales. They did not show any significant influence on the intra- and inter-annual variations of biological parameters like growth, VS and maturation, supporting that the observed dynamics rather indicate a mixture of populations changing both historically and over the year. However, the high temperature and low salinity observed in the historic time series from Landvikvannet in May could clearly explain the very low VS observed. Moreover, the observed decrease in VS over the 2012 spawning season in Landvik and connected fjords was significantly related to increasing temperatures, which could indicate a tendency of herring returning to spawn in the same part of the season and in similar environment as their parents. To conclude the combination of data at different scales clearly suggests high dynamics in population structure along the south coast of Norway, and even though differentiation in peak spawning may occur the clear overlap in spawning stages observed in herring diverging phenotypically provides strong indications of regular interbreeding between populations, thereby supporting the metapopulation concept.\n",
+            "alternativeAbstracts": {},
+            "contributors": [
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Arne Johannessen"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              },
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Esben Moland Olsen"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              },
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Aril Slotte"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              },
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Florian Eggers"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              }
+            ],
+            "description": "-\n",
+            "language": "http://lexvo.org/id/iso639-3/eng",
+            "mainTitle": "Metapopulation dynamics in Atlantic herring (Clupea harengus L.) along the coast of southern Norway and in the local area of Landvikvannet",
+            "publicationDate": {
+              "type": "PublicationDate",
+              "year": "2013"
+            },
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Degree"
+              },
+              "publicationInstance": {
+                "type": "DegreeMaster",
+                "pages": {
+                  "type": "MonographPages",
+                  "illustrated": false
+                },
+                "submittedDate": {
+                  "type": "PublicationDate",
+                  "year": "2013"
+                }
+              }
+            }
+          },
+          "handle": "https://hdl.handle.net/1956/9436",
+          "identifier": "018925500896-9cd6cfd1-114b-4279-b472-0858e0dfc3de",
+          "modelVersion": "0.20.36",
+          "modifiedDate": "2023-07-25T14:07:41.735928Z",
+          "nviType": "NonNviCandidate",
+          "publishedDate": "2015-01-30T10:12:29Z",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/customer/b4497570-2903-49a2-9c2a-d6ab8b0eacc2",
+            "type": "Organization"
+          },
+          "resourceOwner": {
+            "owner": "nve@5948.0.0.0",
+            "ownerAffiliation": "https://api.sandbox.nva.aws.unit.no/cristin/organization/5948.0.0.0"
+          },
+          "status": "PUBLISHED"
+        },
+        "sort": [
+          1690294061735
+        ]
+      },
+      {
+        "_index": "resources",
+        "_id": "01892576cac3-f3dae817-3f1a-4fbb-bad8-fddc30530690",
+        "_score": null,
+        "_source": {
+          "type": "Publication",
+          "publicationContextUris": [],
+          "@context": {
+            "@vocab": "https://nva.sikt.no/ontology/publication#",
+            "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+            "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+            "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+            "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+            "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+            "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+            "Film": "https://nva.sikt.no/ontology/publication#Film",
+            "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+            "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+            "source": {
+              "@type": "@id"
+            },
+            "approvedBy": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+              },
+              "@type": "@vocab"
+            },
+            "activeFrom": {
+              "@type": "xsd:dateTime"
+            },
+            "activeTo": {
+              "@type": "xsd:dateTime"
+            },
+            "additionalIdentifiers": {
+              "@container": "@set",
+              "@id": "additionalIdentifier"
+            },
+            "affiliations": {
+              "@container": "@set",
+              "@id": "affiliation"
+            },
+            "alternativeTitles": {
+              "@container": "@language",
+              "@id": "alternativeTitle"
+            },
+            "approvals": {
+              "@container": "@set",
+              "@id": "approval"
+            },
+            "approvalStatus": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "architectureOutput": {
+              "@container": "@set",
+              "@id": "architectureOutput"
+            },
+            "associatedArtifacts": {
+              "@container": "@set",
+              "@id": "associatedArtifact"
+            },
+            "compliesWith": {
+              "@container": "@set",
+              "@id": "compliesWith"
+            },
+            "concertProgramme": {
+              "@container": "@set",
+              "@id": "concertProgramme"
+            },
+            "contributors": {
+              "@container": "@set",
+              "@id": "contributor"
+            },
+            "createdDate": {
+              "@type": "xsd:dateTime"
+            },
+            "doi": {
+              "@type": "@id"
+            },
+            "embargoDate": {
+              "@type": "xsd:dateTime"
+            },
+            "from": {
+              "@type": "xsd:dateTime"
+            },
+            "fundings": {
+              "@container": "@set",
+              "@id": "funding"
+            },
+            "handle": {
+              "@type": "@id"
+            },
+            "id": "@id",
+            "indexedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "isbnList": {
+              "@container": "@set",
+              "@id": "isbn"
+            },
+            "labels": {
+              "@container": "@language",
+              "@id": "label"
+            },
+            "language": {
+              "@type": "@id"
+            },
+            "link": {
+              "@type": "@id"
+            },
+            "manifestations": {
+              "@container": "@set",
+              "@id": "manifestation"
+            },
+            "metadataSource": {
+              "@type": "@id"
+            },
+            "modifiedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "musicalWorks": {
+              "@container": "@set",
+              "@id": "musicalWork"
+            },
+            "nameType": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "outputs": {
+              "@container": "@set",
+              "@id": "output"
+            },
+            "ownerAffiliation": {
+              "@type": "@id"
+            },
+            "projects": {
+              "@container": "@set",
+              "@id": "project"
+            },
+            "publishedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "referencedBy": {
+              "@container": "@set",
+              "@id": "referencedBy"
+            },
+            "related": {
+              "@container": "@set",
+              "@id": "related"
+            },
+            "status": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "subjects": {
+              "@container": "@set",
+              "@id": "subject",
+              "@type": "@id"
+            },
+            "tags": {
+              "@container": "@set",
+              "@id": "tag"
+            },
+            "to": {
+              "@type": "xsd:dateTime"
+            },
+            "trackList": {
+              "@container": "@set",
+              "@id": "trackList"
+            },
+            "type": "@type",
+            "venues": {
+              "@container": "@set",
+              "@id": "venue"
+            },
+            "nviType": {
+              "@type": "@vocab",
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              }
+            },
+            "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+            "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+            "publicationContextUris": {
+              "@container": "@set"
+            }
+          },
+          "id": "https://api.dev.nva.aws.unit.no/publication/01892576cac3-f3dae817-3f1a-4fbb-bad8-fddc30530690",
+          "additionalIdentifiers": [
+            {
+              "type": "AdditionalIdentifier",
+              "sourceName": "Cristin",
+              "value": "1613418"
+            }
+          ],
+          "associatedArtifacts": [
+            {
+              "type": "PublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "7db9844f-3959-44b5-9082-916ca3c90e70",
+              "mimeType": "application/pdf",
+              "name": "REL500+2011+vsr+Masteroppgave+Ingvild+Bergan.pdf",
+              "publishedDate": "2023-07-05T09:51:29.469779Z",
+              "publisherAuthority": true,
+              "size": 578441,
+              "visibleForNonOwner": true
+            }
+          ],
+          "createdDate": "2018-09-26T08:31:44Z",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "alternativeAbstracts": {},
+            "alternativeTitles": {
+              "no": "Bør det norske helsesystemet prioritere ressurssvake pasienter over resurssterke? : en filosofisk analyse av et offentlig verdispørsmål"
+            },
+            "contributors": [
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Ingvild Bergan"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              },
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Terje Mesel"
+                },
+                "role": {
+                  "type": "Advisor"
+                }
+              }
+            ],
+            "language": "http://lexvo.org/id/iso639-3/nob",
+            "mainTitle": "Bør det norske helsesystemet prioritere ressurssvake pasienter over resurssterke? : en filosofisk analyse av et offentlig verdispørsmål",
+            "publicationDate": {
+              "type": "PublicationDate",
+              "year": "2011"
+            },
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Degree",
+                "publisher": {
+                  "type": "UnconfirmedPublisher",
+                  "name": "Universitetet i Agder",
+                  "valid": true
+                }
+              },
+              "publicationInstance": {
+                "type": "DegreeMaster",
+                "pages": {
+                  "type": "MonographPages",
+                  "illustrated": false,
+                  "pages": "89"
+                },
+                "submittedDate": {
+                  "type": "PublicationDate",
+                  "year": "2011"
+                }
+              }
+            }
+          },
+          "handle": "https://hdl.handle.net/11250/2564616",
+          "identifier": "01892576cac3-f3dae817-3f1a-4fbb-bad8-fddc30530690",
+          "modelVersion": "0.20.36",
+          "modifiedDate": "2023-07-25T10:55:40.941316Z",
+          "nviType": "NonNviCandidate",
+          "publishedDate": "2018-09-26T08:31:44Z",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/customer/b4497570-2903-49a2-9c2a-d6ab8b0eacc2",
+            "type": "Organization"
+          },
+          "resourceOwner": {
+            "owner": "nve@5948.0.0.0",
+            "ownerAffiliation": "https://api.sandbox.nva.aws.unit.no/cristin/organization/5948.0.0.0"
+          },
+          "status": "PUBLISHED"
+        },
+        "sort": [
+          1690282540941
+        ]
+      },
+      {
+        "_index": "resources",
+        "_id": "01892591ada8-e8a3c782-ae7d-491b-a3d9-bdbf241ccff2",
+        "_score": null,
+        "_source": {
+          "type": "Publication",
+          "publicationContextUris": [],
+          "@context": {
+            "@vocab": "https://nva.sikt.no/ontology/publication#",
+            "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+            "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+            "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+            "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+            "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+            "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+            "Film": "https://nva.sikt.no/ontology/publication#Film",
+            "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+            "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+            "source": {
+              "@type": "@id"
+            },
+            "approvedBy": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+              },
+              "@type": "@vocab"
+            },
+            "activeFrom": {
+              "@type": "xsd:dateTime"
+            },
+            "activeTo": {
+              "@type": "xsd:dateTime"
+            },
+            "additionalIdentifiers": {
+              "@container": "@set",
+              "@id": "additionalIdentifier"
+            },
+            "affiliations": {
+              "@container": "@set",
+              "@id": "affiliation"
+            },
+            "alternativeTitles": {
+              "@container": "@language",
+              "@id": "alternativeTitle"
+            },
+            "approvals": {
+              "@container": "@set",
+              "@id": "approval"
+            },
+            "approvalStatus": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "architectureOutput": {
+              "@container": "@set",
+              "@id": "architectureOutput"
+            },
+            "associatedArtifacts": {
+              "@container": "@set",
+              "@id": "associatedArtifact"
+            },
+            "compliesWith": {
+              "@container": "@set",
+              "@id": "compliesWith"
+            },
+            "concertProgramme": {
+              "@container": "@set",
+              "@id": "concertProgramme"
+            },
+            "contributors": {
+              "@container": "@set",
+              "@id": "contributor"
+            },
+            "createdDate": {
+              "@type": "xsd:dateTime"
+            },
+            "doi": {
+              "@type": "@id"
+            },
+            "embargoDate": {
+              "@type": "xsd:dateTime"
+            },
+            "from": {
+              "@type": "xsd:dateTime"
+            },
+            "fundings": {
+              "@container": "@set",
+              "@id": "funding"
+            },
+            "handle": {
+              "@type": "@id"
+            },
+            "id": "@id",
+            "indexedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "isbnList": {
+              "@container": "@set",
+              "@id": "isbn"
+            },
+            "labels": {
+              "@container": "@language",
+              "@id": "label"
+            },
+            "language": {
+              "@type": "@id"
+            },
+            "link": {
+              "@type": "@id"
+            },
+            "manifestations": {
+              "@container": "@set",
+              "@id": "manifestation"
+            },
+            "metadataSource": {
+              "@type": "@id"
+            },
+            "modifiedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "musicalWorks": {
+              "@container": "@set",
+              "@id": "musicalWork"
+            },
+            "nameType": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "outputs": {
+              "@container": "@set",
+              "@id": "output"
+            },
+            "ownerAffiliation": {
+              "@type": "@id"
+            },
+            "projects": {
+              "@container": "@set",
+              "@id": "project"
+            },
+            "publishedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "referencedBy": {
+              "@container": "@set",
+              "@id": "referencedBy"
+            },
+            "related": {
+              "@container": "@set",
+              "@id": "related"
+            },
+            "status": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "subjects": {
+              "@container": "@set",
+              "@id": "subject",
+              "@type": "@id"
+            },
+            "tags": {
+              "@container": "@set",
+              "@id": "tag"
+            },
+            "to": {
+              "@type": "xsd:dateTime"
+            },
+            "trackList": {
+              "@container": "@set",
+              "@id": "trackList"
+            },
+            "type": "@type",
+            "venues": {
+              "@container": "@set",
+              "@id": "venue"
+            },
+            "nviType": {
+              "@type": "@vocab",
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              }
+            },
+            "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+            "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+            "publicationContextUris": {
+              "@container": "@set"
+            }
+          },
+          "id": "https://api.dev.nva.aws.unit.no/publication/01892591ada8-e8a3c782-ae7d-491b-a3d9-bdbf241ccff2",
+          "additionalIdentifiers": [
+            {
+              "type": "AdditionalIdentifier",
+              "sourceName": "Cristin",
+              "value": "1572375"
+            }
+          ],
+          "associatedArtifacts": [
+            {
+              "type": "PublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "d33169dd-6ed7-43c9-b430-9ecb1a61219f",
+              "mimeType": "application/pdf",
+              "name": "Thesis.pdf",
+              "publishedDate": "2023-07-05T10:20:51.490733Z",
+              "publisherAuthority": true,
+              "size": 7611006,
+              "visibleForNonOwner": true
+            }
+          ],
+          "createdDate": "2018-03-15T07:37:24Z",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "abstract": "Reinforcement Learning (RL) is a research area that has blossomed tremendously in recent years and has shown remarkable potential for artificial intelligence based opponents in computer games. This success is primarily due to vast capabilities of Convolutional Neural Networks (ConvNet), enabling algorithms to extract useful information from noisy environments. Capsule Network (CapsNet) is a recent introduction to the Deep Learning algorithm group and has only barely begun to be explored. The network is an architecture for image classification, with superior performance for classification of the MNIST dataset. CapsNets have not been explored beyond image classification. This thesis introduces the use of CapsNet for Q-Learning based game algorithms. To successfully apply CapsNet in advanced game play, three main contributions follow. First, the introduction of four new game environments as frameworks for RL research with increasing complexity, namely Flash RL, Deep Line Wars, Deep RTS, and Deep Maze. These environments fill the gap between relatively simple and more complex game environments available for RL research and are in the thesis used to test and explore the CapsNet behavior. Second, the thesis introduces a generative modeling approach to produce artificial training data for use in Deep Learning models including CapsNets. We empirically show that conditional generative modeling can successfully generate game data of sufficient quality to train a Deep Q-Network well. Third, we show that CapsNet is a reliable architecture for Deep Q-Learning based algorithms for game AI. A capsule is a group of neurons that determine the presence of objects in the data and is in the literature shown to increase the robustness of training and predictions while lowering the amount training data needed. It should, therefore, be ideally suited for game plays.\n",
+            "alternativeAbstracts": {},
+            "contributors": [
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Ole-Christoffer Granmo"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              },
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Per-Arne Andersen"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              },
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Morten Goodwin"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              }
+            ],
+            "language": "http://lexvo.org/id/iso639-3/eng",
+            "mainTitle": "Deep Reinforcement Learning using Capsules in Advanced Game Environments",
+            "publicationDate": {
+              "type": "PublicationDate",
+              "year": "2018"
+            },
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Degree",
+                "publisher": {
+                  "type": "UnconfirmedPublisher",
+                  "name": "Universitetet i Agder",
+                  "valid": true
+                }
+              },
+              "publicationInstance": {
+                "type": "DegreeMaster",
+                "pages": {
+                  "type": "MonographPages",
+                  "illustrated": false,
+                  "pages": "144"
+                },
+                "submittedDate": {
+                  "type": "PublicationDate",
+                  "year": "2018"
+                }
+              }
+            }
+          },
+          "handle": "https://hdl.handle.net/11250/2490576",
+          "identifier": "01892591ada8-e8a3c782-ae7d-491b-a3d9-bdbf241ccff2",
+          "modelVersion": "0.20.36",
+          "modifiedDate": "2023-07-25T10:33:39.219977Z",
+          "nviType": "NonNviCandidate",
+          "publishedDate": "2018-03-15T07:37:24Z",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/customer/b4497570-2903-49a2-9c2a-d6ab8b0eacc2",
+            "type": "Organization"
+          },
+          "resourceOwner": {
+            "owner": "nve@5948.0.0.0",
+            "ownerAffiliation": "https://api.sandbox.nva.aws.unit.no/cristin/organization/5948.0.0.0"
+          },
+          "status": "PUBLISHED"
+        },
+        "sort": [
+          1690281219219
+        ]
+      },
+      {
+        "_index": "resources",
+        "_id": "0189255abdc6-8a6af540-ff33-4402-bfb8-c400c6d0c59e",
+        "_score": null,
+        "_source": {
+          "type": "Publication",
+          "publicationContextUris": [],
+          "@context": {
+            "@vocab": "https://nva.sikt.no/ontology/publication#",
+            "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+            "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+            "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+            "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+            "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+            "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+            "Film": "https://nva.sikt.no/ontology/publication#Film",
+            "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+            "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+            "source": {
+              "@type": "@id"
+            },
+            "approvedBy": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+              },
+              "@type": "@vocab"
+            },
+            "activeFrom": {
+              "@type": "xsd:dateTime"
+            },
+            "activeTo": {
+              "@type": "xsd:dateTime"
+            },
+            "additionalIdentifiers": {
+              "@container": "@set",
+              "@id": "additionalIdentifier"
+            },
+            "affiliations": {
+              "@container": "@set",
+              "@id": "affiliation"
+            },
+            "alternativeTitles": {
+              "@container": "@language",
+              "@id": "alternativeTitle"
+            },
+            "approvals": {
+              "@container": "@set",
+              "@id": "approval"
+            },
+            "approvalStatus": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "architectureOutput": {
+              "@container": "@set",
+              "@id": "architectureOutput"
+            },
+            "associatedArtifacts": {
+              "@container": "@set",
+              "@id": "associatedArtifact"
+            },
+            "compliesWith": {
+              "@container": "@set",
+              "@id": "compliesWith"
+            },
+            "concertProgramme": {
+              "@container": "@set",
+              "@id": "concertProgramme"
+            },
+            "contributors": {
+              "@container": "@set",
+              "@id": "contributor"
+            },
+            "createdDate": {
+              "@type": "xsd:dateTime"
+            },
+            "doi": {
+              "@type": "@id"
+            },
+            "embargoDate": {
+              "@type": "xsd:dateTime"
+            },
+            "from": {
+              "@type": "xsd:dateTime"
+            },
+            "fundings": {
+              "@container": "@set",
+              "@id": "funding"
+            },
+            "handle": {
+              "@type": "@id"
+            },
+            "id": "@id",
+            "indexedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "isbnList": {
+              "@container": "@set",
+              "@id": "isbn"
+            },
+            "labels": {
+              "@container": "@language",
+              "@id": "label"
+            },
+            "language": {
+              "@type": "@id"
+            },
+            "link": {
+              "@type": "@id"
+            },
+            "manifestations": {
+              "@container": "@set",
+              "@id": "manifestation"
+            },
+            "metadataSource": {
+              "@type": "@id"
+            },
+            "modifiedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "musicalWorks": {
+              "@container": "@set",
+              "@id": "musicalWork"
+            },
+            "nameType": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "outputs": {
+              "@container": "@set",
+              "@id": "output"
+            },
+            "ownerAffiliation": {
+              "@type": "@id"
+            },
+            "projects": {
+              "@container": "@set",
+              "@id": "project"
+            },
+            "publishedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "referencedBy": {
+              "@container": "@set",
+              "@id": "referencedBy"
+            },
+            "related": {
+              "@container": "@set",
+              "@id": "related"
+            },
+            "status": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "subjects": {
+              "@container": "@set",
+              "@id": "subject",
+              "@type": "@id"
+            },
+            "tags": {
+              "@container": "@set",
+              "@id": "tag"
+            },
+            "to": {
+              "@type": "xsd:dateTime"
+            },
+            "trackList": {
+              "@container": "@set",
+              "@id": "trackList"
+            },
+            "type": "@type",
+            "venues": {
+              "@container": "@set",
+              "@id": "venue"
+            },
+            "nviType": {
+              "@type": "@vocab",
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              }
+            },
+            "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+            "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+            "publicationContextUris": {
+              "@container": "@set"
+            }
+          },
+          "id": "https://api.dev.nva.aws.unit.no/publication/0189255abdc6-8a6af540-ff33-4402-bfb8-c400c6d0c59e",
+          "additionalIdentifiers": [
+            {
+              "type": "AdditionalIdentifier",
+              "sourceName": "Cristin",
+              "value": "1561887"
+            }
+          ],
+          "associatedArtifacts": [
+            {
+              "type": "PublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "bdace857-2765-4df9-b9b8-f49bf170f95a",
+              "mimeType": "application/pdf",
+              "name": "Nordtveit+Espen-Life+Cycle+Assessment+of+a+Battery+Passanger+May17+Ferry.pdf",
+              "publishedDate": "2023-07-05T09:20:51.137165Z",
+              "publisherAuthority": false,
+              "size": 3984351,
+              "visibleForNonOwner": true
+            }
+          ],
+          "createdDate": "2018-04-10T12:19:09Z",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "alternativeAbstracts": {},
+            "contributors": [
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Espen Nordtveit"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              },
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Reyn Joseph O'Born"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              }
+            ],
+            "language": "http://lexvo.org/id/iso639-3/eng",
+            "mainTitle": "Life Cycle Assessment of a Battery Passenger Ferry",
+            "publicationDate": {
+              "type": "PublicationDate",
+              "year": "2017"
+            },
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Degree",
+                "publisher": {
+                  "type": "UnconfirmedPublisher",
+                  "name": "Universitetet i Agder",
+                  "valid": true
+                }
+              },
+              "publicationInstance": {
+                "type": "DegreeMaster",
+                "pages": {
+                  "type": "MonographPages",
+                  "illustrated": false,
+                  "pages": "123"
+                },
+                "submittedDate": {
+                  "type": "PublicationDate",
+                  "year": "2017"
+                }
+              }
+            }
+          },
+          "handle": "https://hdl.handle.net/11250/2493457",
+          "identifier": "0189255abdc6-8a6af540-ff33-4402-bfb8-c400c6d0c59e",
+          "modelVersion": "0.20.36",
+          "modifiedDate": "2023-07-25T10:29:33.869669Z",
+          "nviType": "NonNviCandidate",
+          "publishedDate": "2018-04-10T12:19:09Z",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/customer/b4497570-2903-49a2-9c2a-d6ab8b0eacc2",
+            "type": "Organization"
+          },
+          "resourceOwner": {
+            "owner": "nve@5948.0.0.0",
+            "ownerAffiliation": "https://api.sandbox.nva.aws.unit.no/cristin/organization/5948.0.0.0"
+          },
+          "status": "PUBLISHED"
+        },
+        "sort": [
+          1690280973869
+        ]
+      },
+      {
+        "_index": "resources",
+        "_id": "0187b8a58fa9-b46232f4-ea61-468b-8d71-220be52baf29",
+        "_score": null,
+        "_source": {
+          "type": "Publication",
+          "publicationContextUris": [
+            "https://api.dev.nva.aws.unit.no/publication-channels/publisher/28102/2023"
+          ],
+          "@context": {
+            "@vocab": "https://nva.sikt.no/ontology/publication#",
+            "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+            "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+            "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+            "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+            "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+            "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+            "Film": "https://nva.sikt.no/ontology/publication#Film",
+            "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+            "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+            "source": {
+              "@type": "@id"
+            },
+            "approvedBy": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+              },
+              "@type": "@vocab"
+            },
+            "activeFrom": {
+              "@type": "xsd:dateTime"
+            },
+            "activeTo": {
+              "@type": "xsd:dateTime"
+            },
+            "additionalIdentifiers": {
+              "@container": "@set",
+              "@id": "additionalIdentifier"
+            },
+            "affiliations": {
+              "@container": "@set",
+              "@id": "affiliation"
+            },
+            "alternativeTitles": {
+              "@container": "@language",
+              "@id": "alternativeTitle"
+            },
+            "approvals": {
+              "@container": "@set",
+              "@id": "approval"
+            },
+            "approvalStatus": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "architectureOutput": {
+              "@container": "@set",
+              "@id": "architectureOutput"
+            },
+            "associatedArtifacts": {
+              "@container": "@set",
+              "@id": "associatedArtifact"
+            },
+            "compliesWith": {
+              "@container": "@set",
+              "@id": "compliesWith"
+            },
+            "concertProgramme": {
+              "@container": "@set",
+              "@id": "concertProgramme"
+            },
+            "contributors": {
+              "@container": "@set",
+              "@id": "contributor"
+            },
+            "createdDate": {
+              "@type": "xsd:dateTime"
+            },
+            "doi": {
+              "@type": "@id"
+            },
+            "embargoDate": {
+              "@type": "xsd:dateTime"
+            },
+            "from": {
+              "@type": "xsd:dateTime"
+            },
+            "fundings": {
+              "@container": "@set",
+              "@id": "funding"
+            },
+            "handle": {
+              "@type": "@id"
+            },
+            "id": "@id",
+            "indexedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "isbnList": {
+              "@container": "@set",
+              "@id": "isbn"
+            },
+            "labels": {
+              "@container": "@language",
+              "@id": "label"
+            },
+            "language": {
+              "@type": "@id"
+            },
+            "link": {
+              "@type": "@id"
+            },
+            "manifestations": {
+              "@container": "@set",
+              "@id": "manifestation"
+            },
+            "metadataSource": {
+              "@type": "@id"
+            },
+            "modifiedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "musicalWorks": {
+              "@container": "@set",
+              "@id": "musicalWork"
+            },
+            "nameType": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "outputs": {
+              "@container": "@set",
+              "@id": "output"
+            },
+            "ownerAffiliation": {
+              "@type": "@id"
+            },
+            "projects": {
+              "@container": "@set",
+              "@id": "project"
+            },
+            "publishedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "referencedBy": {
+              "@container": "@set",
+              "@id": "referencedBy"
+            },
+            "related": {
+              "@container": "@set",
+              "@id": "related"
+            },
+            "status": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "subjects": {
+              "@container": "@set",
+              "@id": "subject",
+              "@type": "@id"
+            },
+            "tags": {
+              "@container": "@set",
+              "@id": "tag"
+            },
+            "to": {
+              "@type": "xsd:dateTime"
+            },
+            "trackList": {
+              "@container": "@set",
+              "@id": "trackList"
+            },
+            "type": "@type",
+            "venues": {
+              "@container": "@set",
+              "@id": "venue"
+            },
+            "nviType": {
+              "@type": "@vocab",
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              }
+            },
+            "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+            "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+            "publicationContextUris": {
+              "@container": "@set"
+            }
+          },
+          "id": "https://api.dev.nva.aws.unit.no/publication/0187b8a58fa9-b46232f4-ea61-468b-8d71-220be52baf29",
+          "associatedArtifacts": [
+            {
+              "type": "UnpublishedFile",
+              "administrativeAgreement": false,
+              "embargoDate": "2023-07-04T22:00:00Z",
+              "identifier": "5b961e92-e254-4495-ab9a-8f804b452755",
+              "license": "https://creativecommons.org/licenses/by-sa/4.0",
+              "mimeType": "image/png",
+              "name": "Screenshot 2021-09-20 at 08.34.57.png",
+              "publisherAuthority": false,
+              "size": 53853,
+              "visibleForNonOwner": false
+            },
+            {
+              "type": "PublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "abf92ceb-f449-4721-903d-09321164bd4a",
+              "license": "https://creativecommons.org/licenses/by/4.0",
+              "mimeType": "application/pdf",
+              "name": "sensors-20-04987.pdf",
+              "publishedDate": "2023-04-28T12:02:16.517942Z",
+              "publisherAuthority": false,
+              "size": 2915550,
+              "visibleForNonOwner": true
+            },
+            {
+              "type": "UnpublishedFile",
+              "administrativeAgreement": false,
+              "embargoDate": "2023-07-16T22:00:00Z",
+              "identifier": "67e76394-75a6-41e6-8dbf-f5b828b87da4",
+              "license": "https://creativecommons.org/licenses/by-sa/4.0",
+              "mimeType": "application/pdf",
+              "name": "A17_FlightPlan.pdf",
+              "publisherAuthority": false,
+              "size": 20702285,
+              "visibleForNonOwner": false
+            },
+            {
+              "type": "UnpublishedFile",
+              "administrativeAgreement": false,
+              "embargoDate": "2023-07-02T22:00:00Z",
+              "identifier": "808f1438-9eb7-4c41-90c9-ab9c9ac2fef7",
+              "license": "https://creativecommons.org/licenses/by-nd/4.0",
+              "mimeType": "image/svg+xml",
+              "name": "button-rights-reserved.svg",
+              "publisherAuthority": false,
+              "size": 5101,
+              "visibleForNonOwner": false
+            },
+            {
+              "type": "UnpublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "52def659-c20b-43c4-8f20-bfb666c5f88d",
+              "license": "https://creativecommons.org/licenses/by-sa/4.0",
+              "mimeType": "image/jpeg",
+              "name": "osteloff.jpg",
+              "publisherAuthority": false,
+              "size": 4656,
+              "visibleForNonOwner": false
+            }
+          ],
+          "createdDate": "2023-04-25T13:41:10.697327Z",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "abstract": "Sammendrag av Masteroppgave",
+            "alternativeAbstracts": {
+              "und": "Her er alternativt sammendrag"
+            },
+            "alternativeTitles": {
+              "und": "Her er alternativ tittel"
+            },
+            "contributors": [
+              {
+                "type": "Contributor",
+                "affiliations": [
+                  {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0",
+                    "type": "Organization",
+                    "labels": {
+                      "en": "Faculty of Information Technology and Electrical Engineering",
+                      "nb": "Fakultet for informasjonsteknologi og elektroteknikk"
+                    },
+                    "name": [
+                      {
+                        "@language": "en",
+                        "@value": "Faculty of Information Technology and Electrical Engineering"
+                      },
+                      {
+                        "@language": "nb",
+                        "@value": "Fakultet for informasjonsteknologi og elektroteknikk"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
+                    "type": "Organization",
+                    "labels": {
+                      "en": "Norwegian University of Science and Technology",
+                      "nb": "Norges teknisk-naturvitenskapelige universitet",
+                      "nn": "Noregs teknisk-naturvitskaplege universitet"
+                    },
+                    "name": [
+                      {
+                        "@language": "nn",
+                        "@value": "Noregs teknisk-naturvitskaplege universitet"
+                      },
+                      {
+                        "@language": "en",
+                        "@value": "Norwegian University of Science and Technology"
+                      },
+                      {
+                        "@language": "nb",
+                        "@value": "Norges teknisk-naturvitenskapelige universitet"
+                      }
+                    ]
+                  }
+                ],
+                "correspondingAuthor": false,
+                "identity": {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/person/1128464",
+                  "type": "Identity",
+                  "name": "Terje Hellesvik",
+                  "orcId": "https://sandbox.orcid.org/0000-0002-8617-3281"
+                },
+                "role": {
+                  "type": "Creator"
+                },
+                "sequence": 1
+              },
+              {
+                "type": "Contributor",
+                "affiliations": [
+                  {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
+                    "type": "Organization",
+                    "labels": {
+                      "nb": "Sikt – Kunnskapssektorens tjenesteleverandør",
+                      "en": "Sikt - Norwegian Agency for Shared Services in Education and Research"
+                    },
+                    "name": [
+                      {
+                        "@language": "en",
+                        "@value": "Sikt - Norwegian Agency for Shared Services in Education and Research"
+                      },
+                      {
+                        "@language": "nb",
+                        "@value": "Sikt – Kunnskapssektorens tjenesteleverandør"
+                      }
+                    ]
+                  }
+                ],
+                "correspondingAuthor": false,
+                "identity": {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/person/42557",
+                  "type": "Identity",
+                  "name": "Jan Erik Grashol"
+                },
+                "role": {
+                  "type": "Supervisor"
+                },
+                "sequence": 2
+              }
+            ],
+            "language": "http://lexvo.org/id/iso639-3/nob",
+            "mainTitle": "Test av Masteroppgave",
+            "publicationDate": {
+              "type": "PublicationDate",
+              "day": "24",
+              "month": "4",
+              "year": "2023"
+            },
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Degree",
+                "publisher": {
+                  "id": "https://api.dev.nva.aws.unit.no/publication-channels/publisher/28102/2023",
+                  "type": "Publisher",
+                  "active": true,
+                  "identifier": "28102",
+                  "level": "0",
+                  "name": "Norges teknisk-naturvitenskapelige universitet",
+                  "valid": true,
+                  "website": {
+                    "id": "https://www.ntnu.no/"
+                  }
+                },
+                "series": {
+                  "type": "UnconfirmedSeries"
+                }
+              },
+              "publicationInstance": {
+                "type": "DegreeMaster",
+                "pages": {
+                  "type": "MonographPages",
+                  "illustrated": false,
+                  "pages": "154"
+                }
+              }
+            }
+          },
+          "identifier": "0187b8a58fa9-b46232f4-ea61-468b-8d71-220be52baf29",
+          "modelVersion": "0.20.36",
+          "modifiedDate": "2023-07-05T13:05:14.266398Z",
+          "nviType": "NonNviCandidate",
+          "publishedDate": "2023-04-25T13:52:04.635156Z",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/customer/bb3d0c0c-5065-4623-9b98-5810983c2478",
+            "type": "Organization"
+          },
+          "resourceOwner": {
+            "owner": "1128464@20754.0.0.0",
+            "ownerAffiliation": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"
+          },
+          "status": "PUBLISHED",
+          "topLevelOrganization": [
+            {
+              "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
+              "type": "Organization",
+              "hasPart": [
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.13.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "FO",
+                  "labels": {
+                    "nb": "Prorektor for forskning",
+                    "en": "Pro-Rector for Research"
+                  },
+                  "name": [
+                    {
+                      "@language": "nb",
+                      "@value": "Prorektor for forskning"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "Pro-Rector for Research"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "VM",
+                  "hasPart": [
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.15.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "VM-SF",
+                      "labels": {
+                        "nb": "Seksjon for formidling",
+                        "en": "Department of Public Outreach and Exhibitions"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Seksjon for formidling"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Public Outreach and Exhibitions"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.15.15",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "VM-ND",
+                      "labels": {
+                        "nb": "Nasjonallaboratoriene for datering",
+                        "en": "National Laboratory for Age Determination"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Nasjonallaboratoriene for datering"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "National Laboratory for Age Determination"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.1.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "VM-ADM",
+                      "labels": {
+                        "nb": "Vitenskapsmuseet administrasjon",
+                        "en": "Museum administration"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Vitenskapsmuseet administrasjon"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Museum administration"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.5.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "VM-IAK",
+                      "labels": {
+                        "nb": "Institutt for arkeologi og kulturhistorie",
+                        "en": "Department of Archaeology and Cultural History"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for arkeologi og kulturhistorie"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Archaeology and Cultural History"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.10.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "VM-INH",
+                      "labels": {
+                        "nb": "Institutt for naturhistorie",
+                        "en": "Department of Natural History"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for naturhistorie"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Natural History"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.31.0.0"
+                      }
+                    }
+                  ],
+                  "labels": {
+                    "en": "NTNU University Museum",
+                    "nb": "NTNU Vitenskapsmuseet"
+                  },
+                  "name": [
+                    {
+                      "@language": "nb",
+                      "@value": "NTNU Vitenskapsmuseet"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "NTNU University Museum"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH",
+                  "hasPart": [
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.70.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-IHG",
+                      "hasPart": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.70.20",
+                        "type": "Organization",
+                        "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-IHG-OMS",
+                        "labels": {
+                          "nb": "Senter for omsorgsforskning",
+                          "en": "Center for Care Research"
+                        },
+                        "name": [
+                          {
+                            "@language": "nb",
+                            "@value": "Senter for omsorgsforskning"
+                          },
+                          {
+                            "@language": "en",
+                            "@value": "Center for Care Research"
+                          }
+                        ],
+                        "partOf": {
+                          "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.70.0"
+                        }
+                      },
+                      "labels": {
+                        "nb": "Institutt for helsevitenskap Gjøvik",
+                        "en": "Department of Health Sciences Gjøvik"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for helsevitenskap Gjøvik"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Health Sciences Gjøvik"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.15.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-IKOM",
+                      "labels": {
+                        "nb": "Institutt for klinisk og molekylær medisin",
+                        "en": "Department of Clinical and Molecular Medicine"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for klinisk og molekylær medisin"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Clinical and Molecular Medicine"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.20.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-ISM",
+                      "hasPart": [
+                        {
+                          "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.20.15",
+                          "type": "Organization",
+                          "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-ISM-HUN",
+                          "labels": {
+                            "nb": "Helseundersøkelsen i Nord-Trøndelag",
+                            "en": "The Nord-Trøndelag Health Study"
+                          },
+                          "name": [
+                            {
+                              "@language": "nb",
+                              "@value": "Helseundersøkelsen i Nord-Trøndelag"
+                            },
+                            {
+                              "@language": "en",
+                              "@value": "The Nord-Trøndelag Health Study"
+                            }
+                          ],
+                          "partOf": {
+                            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.20.0"
+                          }
+                        },
+                        {
+                          "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.20.10",
+                          "type": "Organization",
+                          "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "AFE",
+                          "labels": {
+                            "nb": "Allmennmedisinsk forskningsenhet i Trondheim"
+                          },
+                          "name": {
+                            "@language": "nb",
+                            "@value": "Allmennmedisinsk forskningsenhet i Trondheim"
+                          },
+                          "partOf": {
+                            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.20.0"
+                          }
+                        }
+                      ],
+                      "labels": {
+                        "nb": "Institutt for samfunnsmedisin og sykepleie",
+                        "en": "Department of Public Health and Nursing"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for samfunnsmedisin og sykepleie"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Public Health and Nursing"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.35.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-IPH",
+                      "hasPart": [
+                        {
+                          "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.35.20",
+                          "type": "Organization",
+                          "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-IPH-NAK",
+                          "labels": {
+                            "nb": "Nasjonalt kompetansemiljø om utviklingshemming (NAKU)",
+                            "en": "The National Institute on Intellectual Disability and Community"
+                          },
+                          "name": [
+                            {
+                              "@language": "nb",
+                              "@value": "Nasjonalt kompetansemiljø om utviklingshemming (NAKU)"
+                            },
+                            {
+                              "@language": "en",
+                              "@value": "The National Institute on Intellectual Disability and Community"
+                            }
+                          ],
+                          "partOf": {
+                            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.35.0"
+                          }
+                        },
+                        {
+                          "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.35.5",
+                          "type": "Organization",
+                          "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-IPH-RKB",
+                          "labels": {
+                            "nb": "RKBU Midt-Norge - Regionalt kunnskapssenter for barn og unge - psykisk helse og barnevern",
+                            "en": "Regional Centre for Child and Youth Mental Health and Child Welfare"
+                          },
+                          "name": [
+                            {
+                              "@language": "nb",
+                              "@value": "RKBU Midt-Norge - Regionalt kunnskapssenter for barn og unge - psykisk helse og barnevern"
+                            },
+                            {
+                              "@language": "en",
+                              "@value": "Regional Centre for Child and Youth Mental Health and Child Welfare"
+                            }
+                          ],
+                          "partOf": {
+                            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.35.0"
+                          }
+                        }
+                      ],
+                      "labels": {
+                        "nb": "Institutt for psykisk helse",
+                        "en": "Department of Mental Health"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for psykisk helse"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Mental Health"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.80.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-IHA",
+                      "labels": {
+                        "nb": "Institutt for helsevitenskap Ålesund",
+                        "en": "Department of Health Sciences Ålesund"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for helsevitenskap Ålesund"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Health Sciences Ålesund"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.25.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-ISB",
+                      "labels": {
+                        "nb": "Institutt for sirkulasjon og bildediagnostikk",
+                        "en": "Department of Circulation and Medical Imaging"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for sirkulasjon og bildediagnostikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Circulation and Medical Imaging"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.60.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-KIN",
+                      "labels": {
+                        "nb": "Kavliinstitutt for nevrovitenskap",
+                        "en": "Kavli Institute for Systems Neuroscience"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Kavliinstitutt for nevrovitenskap"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Kavli Institute for Systems Neuroscience"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.30.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-INB",
+                      "labels": {
+                        "nb": "Institutt for nevromedisin og bevegelsesvitenskap",
+                        "en": "Department of Neuromedicine and Movement Science"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for nevromedisin og bevegelsesvitenskap"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Neuromedicine and Movement Science"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.1.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "MH-ADM",
+                      "labels": {
+                        "nb": "MH fakultetsadministrasjon",
+                        "en": "MH Faculty Administration"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "MH fakultetsadministrasjon"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "MH Faculty Administration"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.65.0.0"
+                      }
+                    }
+                  ],
+                  "labels": {
+                    "nb": "Fakultet for medisin og helsevitenskap",
+                    "en": "Faculty of Medicine and Health Sciences"
+                  },
+                  "name": [
+                    {
+                      "@language": "en",
+                      "@value": "Faculty of Medicine and Health Sciences"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Fakultet for medisin og helsevitenskap"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.17.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NY",
+                  "labels": {
+                    "nb": "Prorektor for nyskaping",
+                    "en": "Pro-Rector for Innovation"
+                  },
+                  "name": [
+                    {
+                      "@language": "nb",
+                      "@value": "Prorektor for nyskaping"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "Pro-Rector for Innovation"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "AD",
+                  "hasPart": [
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.55.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "AD-IAT",
+                      "labels": {
+                        "nb": "Institutt for arkitektur og teknologi",
+                        "en": "Department of Architecture and Technology"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for arkitektur og teknologi"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Architecture and Technology"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.30.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "AD-KIT",
+                      "labels": {
+                        "nb": "Kunstakademiet i Trondheim",
+                        "en": "Trondheim Academy of Fine Art"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Kunstakademiet i Trondheim"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Trondheim Academy of Fine Art"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.50.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "AD-IAP",
+                      "labels": {
+                        "nb": "Institutt for arkitektur og planlegging",
+                        "en": "Department of Architecture and Planning"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for arkitektur og planlegging"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Architecture and Planning"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.45.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "AD-ID",
+                      "labels": {
+                        "nb": "Institutt for design",
+                        "en": "Department of Design"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for design"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Design"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.1.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "AD-ADM",
+                      "labels": {
+                        "nb": "AD fakultetsadministrasjon",
+                        "en": "AD Faculty Administration"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "AD fakultetsadministrasjon"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "AD Faculty Administration"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.61.0.0"
+                      }
+                    }
+                  ],
+                  "labels": {
+                    "nb": "Fakultet for arkitektur og design",
+                    "en": "Faculty of Architecture and Design"
+                  },
+                  "name": [
+                    {
+                      "@language": "nb",
+                      "@value": "Fakultet for arkitektur og design"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "Faculty of Architecture and Design"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV",
+                  "hasPart": [
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.25.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV-IKJ",
+                      "labels": {
+                        "nb": "Institutt for kjemi",
+                        "en": "Department of Chemistry"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for kjemi"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Chemistry"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.10.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV-IBI",
+                      "labels": {
+                        "nb": "Institutt for biologi",
+                        "en": "Department of Biology"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for biologi"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Biology"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.30.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV-IKP",
+                      "labels": {
+                        "nb": "Institutt for kjemisk prosessteknologi",
+                        "en": "Department of Chemical Engineering"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for kjemisk prosessteknologi"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Chemical Engineering"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.35.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV-IMA",
+                      "labels": {
+                        "nb": "Institutt for materialteknologi",
+                        "en": "Department of Materials Science and Engineering"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for materialteknologi"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Materials Science and Engineering"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.15.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV-IBT",
+                      "labels": {
+                        "nb": "Institutt for bioteknologi og matvitenskap",
+                        "en": "Department of Biotechnology and Food Science"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for bioteknologi og matvitenskap"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Biotechnology and Food Science"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.40.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV-IBF",
+                      "labels": {
+                        "nb": "Institutt for bioingeniørfag",
+                        "en": "Department of Biomedical Laboratory Science"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for bioingeniørfag"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Biomedical Laboratory Science"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.50.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV-FELLES",
+                      "labels": {
+                        "nb": "Felles forskningsinfrastruktur",
+                        "en": "Research Infrastructure"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Felles forskningsinfrastruktur"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Research Infrastructure"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.1.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV-ADM",
+                      "labels": {
+                        "nb": "NV fakultetsadministrasjon",
+                        "en": "NV Faculty Administration"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "NV fakultetsadministrasjon"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "NV Faculty Administration"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.20.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV-IFY",
+                      "labels": {
+                        "nb": "Institutt for fysikk",
+                        "en": "Department of Physics"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for fysikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Physics"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.45.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "NV-IBA",
+                      "labels": {
+                        "nb": "Institutt for biologiske fag Ålesund",
+                        "en": "Department of Biological Sciences Ålesund"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for biologiske fag Ålesund"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Biological Sciences Ålesund"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.66.0.0"
+                      }
+                    }
+                  ],
+                  "labels": {
+                    "nb": "Fakultet for naturvitenskap",
+                    "en": "Faculty of Natural Sciences"
+                  },
+                  "name": [
+                    {
+                      "@language": "nb",
+                      "@value": "Fakultet for naturvitenskap"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "Faculty of Natural Sciences"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.14.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "UTD",
+                  "hasPart": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.14.30.0",
+                    "type": "Organization",
+                    "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "UTD-UB",
+                    "labels": {
+                      "nb": "NTNU Universitetsbiblioteket",
+                      "en": "NTNU University Library"
+                    },
+                    "name": [
+                      {
+                        "@language": "nb",
+                        "@value": "NTNU Universitetsbiblioteket"
+                      },
+                      {
+                        "@language": "en",
+                        "@value": "NTNU University Library"
+                      }
+                    ],
+                    "partOf": {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.14.0.0"
+                    }
+                  },
+                  "labels": {
+                    "nb": "Prorektor for utdanning",
+                    "en": "Pro-Rector for Education"
+                  },
+                  "name": [
+                    {
+                      "@language": "nb",
+                      "@value": "Prorektor for utdanning"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "Pro-Rector for Education"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IV",
+                  "hasPart": [
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.20.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IV-IMT",
+                      "labels": {
+                        "nb": "Institutt for marin teknikk",
+                        "en": "Department of Marine Technology"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for marin teknikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Marine Technology"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.80.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "AMOS",
+                      "labels": {
+                        "nb": "Senter for autonome marine operasjoner og systemer",
+                        "en": "Centre for autonomous marine operations and systems"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Senter for autonome marine operasjoner og systemer"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Centre for autonomous marine operations and systems"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.45.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IV-KT",
+                      "labels": {
+                        "nb": "Institutt for konstruksjonsteknikk",
+                        "en": "Department of Structural Engineering"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for konstruksjonsteknikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Structural Engineering"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.1.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IV-ADM",
+                      "labels": {
+                        "nb": "IV fakultetsadministrasjon",
+                        "en": "IV Faculty Administration"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "IV fakultetsadministrasjon"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "IV Faculty Administration"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.94.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IV-IVB",
+                      "labels": {
+                        "nb": "Institutt for vareproduksjon og byggteknikk",
+                        "en": "Department of Manufacturing and Civil Engineering"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for vareproduksjon og byggteknikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Manufacturing and Civil Engineering"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.92.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IV-MTP",
+                      "labels": {
+                        "nb": "Institutt for maskinteknikk og produksjon",
+                        "en": "Department of Mechanical and Industrial Engineering"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for maskinteknikk og produksjon"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Mechanical and Industrial Engineering"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.25.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IV-EPT",
+                      "labels": {
+                        "nb": "Institutt for energi- og prosessteknikk",
+                        "en": "Department of Energy and Process Engineering"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for energi- og prosessteknikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Energy and Process Engineering"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.93.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IV-IHB",
+                      "labels": {
+                        "nb": "Institutt for havromsoperasjoner og byggteknikk",
+                        "en": "Department of Ocean Operations and Civil Engineering"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for havromsoperasjoner og byggteknikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Ocean Operations and Civil Engineering"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.91.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IV-IBM",
+                      "labels": {
+                        "nb": "Institutt for bygg- og miljøteknikk",
+                        "en": "Department of Civil and Environmental Engineering"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for bygg- og miljøteknikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Civil and Environmental Engineering"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.90.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IV-IGP",
+                      "labels": {
+                        "nb": "Institutt for geovitenskap og petroleum",
+                        "en": "Department of Geoscience and Petroleum"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for geovitenskap og petroleum"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Geoscience and Petroleum"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.0.0"
+                      }
+                    }
+                  ],
+                  "labels": {
+                    "en": "Faculty of Engineering",
+                    "nb": "Fakultet for ingeniørvitenskap"
+                  },
+                  "name": [
+                    {
+                      "@language": "en",
+                      "@value": "Faculty of Engineering"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Fakultet for ingeniørvitenskap"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.35.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "KD-ENHETER",
+                  "labels": {
+                    "nb": "Enheter under Kunnskapdepartementet og Utdanningdirektoratet"
+                  },
+                  "name": {
+                    "@language": "nb",
+                    "@value": "Enheter under Kunnskapdepartementet og Utdanningdirektoratet"
+                  },
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.16.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "OD",
+                  "hasPart": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.16.90.0",
+                    "type": "Organization",
+                    "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "OD-KOMM",
+                    "labels": {
+                      "nb": "Kommunikasjonsavdelingen",
+                      "en": "Communication Division"
+                    },
+                    "name": [
+                      {
+                        "@language": "nb",
+                        "@value": "Kommunikasjonsavdelingen"
+                      },
+                      {
+                        "@language": "en",
+                        "@value": "Communication Division"
+                      }
+                    ],
+                    "partOf": {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.16.0.0"
+                    }
+                  },
+                  "labels": {
+                    "nb": "Organisasjonsdirektør",
+                    "en": "Director, Organization"
+                  },
+                  "name": [
+                    {
+                      "@language": "nb",
+                      "@value": "Organisasjonsdirektør"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "Director, Organization"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "OK",
+                  "hasPart": [
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.1.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "OK-ADM",
+                      "labels": {
+                        "nb": "ØK fakultetsadministrasjon",
+                        "en": "Economics and Management Faculty Administration"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "ØK fakultetsadministrasjon"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Economics and Management Faculty Administration"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.20.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "OK-ISO",
+                      "labels": {
+                        "nb": "Institutt for samfunnsøkonomi",
+                        "en": "Department of Economics"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for samfunnsøkonomi"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Economics"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.15.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "OK-IIF",
+                      "labels": {
+                        "nb": "Institutt for internasjonal forretningsdrift",
+                        "en": "Department of International Business"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for internasjonal forretningsdrift"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of International Business"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.25.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "OK-IOT",
+                      "labels": {
+                        "nb": "Institutt for industriell økonomi og teknologiledelse",
+                        "en": "Department of Industrial Economics and Technology Management"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for industriell økonomi og teknologiledelse"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Industrial Economics and Technology Management"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.10.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "OK-HHS",
+                      "labels": {
+                        "nb": "NTNU Handelshøyskolen",
+                        "en": "NTNU Business School"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "NTNU Handelshøyskolen"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "NTNU Business School"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.60.0.0"
+                      }
+                    }
+                  ],
+                  "labels": {
+                    "en": "Faculty of Economics and Management",
+                    "nb": "Fakultet for økonomi"
+                  },
+                  "name": [
+                    {
+                      "@language": "en",
+                      "@value": "Faculty of Economics and Management"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Fakultet for økonomi"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IE",
+                  "hasPart": [
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.35.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IE-IES",
+                      "labels": {
+                        "nb": "Institutt for elektroniske systemer",
+                        "en": "Department of Electronic Systems"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for elektroniske systemer"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Electronic Systems"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.30.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IE-IIK",
+                      "labels": {
+                        "nb": "Institutt for informasjonssikkerhet og kommunikasjonsteknologi",
+                        "en": "Department of Information Security and Communication Technology"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for informasjonssikkerhet og kommunikasjonsteknologi"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Information Security and Communication Technology"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.55.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IE-IIR",
+                      "labels": {
+                        "nb": "Institutt for IKT og realfag",
+                        "en": "Department of ICT and Natural Sciences"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for IKT og realfag"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of ICT and Natural Sciences"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.1.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IE-ADM",
+                      "hasPart": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.1.20",
+                        "type": "Organization",
+                        "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IE-ADM-NSR",
+                        "labels": {
+                          "nb": "Nasjonalt senter for realfagsrekruttering",
+                          "en": "The National Centre for Science Recruitment"
+                        },
+                        "name": [
+                          {
+                            "@language": "nb",
+                            "@value": "Nasjonalt senter for realfagsrekruttering"
+                          },
+                          {
+                            "@language": "en",
+                            "@value": "The National Centre for Science Recruitment"
+                          }
+                        ],
+                        "partOf": {
+                          "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.1.0"
+                        }
+                      },
+                      "labels": {
+                        "nb": "IE fakultetsadministrasjon",
+                        "en": "IE Faculty Administration"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "IE fakultetsadministrasjon"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "IE Faculty Administration"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.25.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IE-ITK",
+                      "labels": {
+                        "nb": "Institutt for teknisk kybernetikk",
+                        "en": "Department of Engineering Cybernetics"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for teknisk kybernetikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Engineering Cybernetics"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.20.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IE-IEL",
+                      "labels": {
+                        "nb": "Institutt for elkraftteknikk",
+                        "en": "Department of Electric Power Engineering"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for elkraftteknikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Electric Power Engineering"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.10.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IE-IDI",
+                      "labels": {
+                        "nb": "Institutt for datateknologi og informatikk",
+                        "en": "Department of Computer Science"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for datateknologi og informatikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Computer Science"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.15.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "IE-IMF",
+                      "labels": {
+                        "nb": "Institutt for matematiske fag",
+                        "en": "Department of Mathematical Sciences"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for matematiske fag"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Mathematical Sciences"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.63.0.0"
+                      }
+                    }
+                  ],
+                  "labels": {
+                    "en": "Faculty of Information Technology and Electrical Engineering",
+                    "nb": "Fakultet for informasjonsteknologi og elektroteknikk"
+                  },
+                  "name": [
+                    {
+                      "@language": "en",
+                      "@value": "Faculty of Information Technology and Electrical Engineering"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Fakultet for informasjonsteknologi og elektroteknikk"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "HF",
+                  "hasPart": [
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.40.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "HF-KULT",
+                      "labels": {
+                        "nb": "Institutt for tverrfaglige kulturstudier",
+                        "en": "Department of Interdisciplinary Studies of Culture"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for tverrfaglige kulturstudier"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Interdisciplinary Studies of Culture"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.60.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "HF-ISL",
+                      "labels": {
+                        "nb": "Institutt for språk og litteratur",
+                        "en": "Department of Language and Literature"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for språk og litteratur"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Language and Literature"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.1.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "HF-ADM",
+                      "labels": {
+                        "nb": "HF fakultetsadministrasjon",
+                        "en": "HF faculty administration"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "HF fakultetsadministrasjon"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "HF faculty administration"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.65.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "HF-IHS",
+                      "labels": {
+                        "nb": "Institutt for historiske studier",
+                        "en": "Department of Historical Studies"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for historiske studier"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Historical Studies"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.70.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "HF-IFR",
+                      "labels": {
+                        "nb": "Institutt for filosofi og religionsvitenskap",
+                        "en": "Department of Philosophy and Religious Studies"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for filosofi og religionsvitenskap"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Philosophy and Religious Studies"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.45.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "HF-IMU",
+                      "labels": {
+                        "nb": "Institutt for musikk",
+                        "en": "Department of Music"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for musikk"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Music"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.35.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "HF-IKM",
+                      "labels": {
+                        "nb": "Institutt for kunst- og medievitenskap",
+                        "en": "Department of Art and Media Studies"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for kunst- og medievitenskap"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Art and Media Studies"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.62.0.0"
+                      }
+                    }
+                  ],
+                  "labels": {
+                    "en": "Faculty of Humanities",
+                    "nb": "Det humanistiske fakultet"
+                  },
+                  "name": [
+                    {
+                      "@language": "en",
+                      "@value": "Faculty of Humanities"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Det humanistiske fakultet"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.15.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "OE",
+                  "labels": {
+                    "nb": "Økonomi- og eiendomsdirektør",
+                    "en": "Director of Finance and Property"
+                  },
+                  "name": [
+                    {
+                      "@language": "nb",
+                      "@value": "Økonomi- og eiendomsdirektør"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "Director of Finance and Property"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU",
+                  "hasPart": [
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.45.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU-SA",
+                      "labels": {
+                        "nb": "Institutt for sosialantropologi",
+                        "en": "Department of Social Anthropology"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for sosialantropologi"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Social Anthropology"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.70.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU-IPL",
+                      "labels": {
+                        "nb": "Institutt for pedagogikk og livslang læring",
+                        "en": "Department of Education and Lifelong Learning"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for pedagogikk og livslang læring"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Education and Lifelong Learning"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.80.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU-ILU",
+                      "hasPart": [
+                        {
+                          "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.80.40",
+                          "type": "Organization",
+                          "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU-ILU-NSS",
+                          "labels": {
+                            "nb": "Nasjonalt senter for skriveopplæring og skriveforsking",
+                            "en": "The Norwegian Centre for Writing Education and Research (The Writing Centre)"
+                          },
+                          "name": [
+                            {
+                              "@language": "nb",
+                              "@value": "Nasjonalt senter for skriveopplæring og skriveforsking"
+                            },
+                            {
+                              "@language": "en",
+                              "@value": "The Norwegian Centre for Writing Education and Research (The Writing Centre)"
+                            }
+                          ],
+                          "partOf": {
+                            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.80.0"
+                          }
+                        },
+                        {
+                          "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.80.30",
+                          "type": "Organization",
+                          "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU-ILU-NSM",
+                          "labels": {
+                            "nb": "Nasjonalt senter for matematikk i opplæringen",
+                            "en": "Norwegian Centre for Mathematics Education"
+                          },
+                          "name": [
+                            {
+                              "@language": "nb",
+                              "@value": "Nasjonalt senter for matematikk i opplæringen"
+                            },
+                            {
+                              "@language": "en",
+                              "@value": "Norwegian Centre for Mathematics Education"
+                            }
+                          ],
+                          "partOf": {
+                            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.80.0"
+                          }
+                        }
+                      ],
+                      "labels": {
+                        "nb": "Institutt for lærerutdanning",
+                        "en": "Department of Teacher Education"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for lærerutdanning"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Teacher Education"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.10.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU-IGE",
+                      "labels": {
+                        "nb": "Institutt for geografi",
+                        "en": "Department of Geography"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for geografi"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Geography"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.90.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU-ISA",
+                      "labels": {
+                        "nb": "Institutt for sosialt arbeid",
+                        "en": "Department of Social Work"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for sosialt arbeid"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Social Work"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.40.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU-IPS",
+                      "labels": {
+                        "nb": "Institutt for psykologi",
+                        "en": "Department of Psychology"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for psykologi"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Psychology"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.25.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU-ISS",
+                      "labels": {
+                        "nb": "Institutt for sosiologi og statsvitenskap",
+                        "en": "Department of Sociology and Political Science"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "Institutt for sosiologi og statsvitenskap"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "Department of Sociology and Political Science"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.0.0"
+                      }
+                    },
+                    {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.1.0",
+                      "type": "Organization",
+                      "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "SU-ADM",
+                      "labels": {
+                        "nb": "SU fakultetsadministrasjon",
+                        "en": "SU Faculty Administration"
+                      },
+                      "name": [
+                        {
+                          "@language": "nb",
+                          "@value": "SU fakultetsadministrasjon"
+                        },
+                        {
+                          "@language": "en",
+                          "@value": "SU Faculty Administration"
+                        }
+                      ],
+                      "partOf": {
+                        "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.67.0.0"
+                      }
+                    }
+                  ],
+                  "labels": {
+                    "nb": "Fakultet for samfunns- og utdanningsvitenskap",
+                    "en": "Faculty of Social and Educational Sciences"
+                  },
+                  "name": [
+                    {
+                      "@language": "nb",
+                      "@value": "Fakultet for samfunns- og utdanningsvitenskap"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "Faculty of Social and Educational Sciences"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.12.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "RE",
+                  "hasPart": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.12.1.0",
+                    "type": "Organization",
+                    "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "RE-REK",
+                    "labels": {
+                      "nb": "Rektor og styre",
+                      "en": "Rector and Board"
+                    },
+                    "name": [
+                      {
+                        "@language": "nb",
+                        "@value": "Rektor og styre"
+                      },
+                      {
+                        "@language": "en",
+                        "@value": "Rector and Board"
+                      }
+                    ],
+                    "partOf": {
+                      "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.12.0.0"
+                    }
+                  },
+                  "labels": {
+                    "nb": "Rektor",
+                    "en": "Rector"
+                  },
+                  "name": [
+                    {
+                      "@language": "nb",
+                      "@value": "Rektor"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "Rector"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+                  }
+                }
+              ],
+              "labels": {
+                "en": "Norwegian University of Science and Technology",
+                "nb": "Norges teknisk-naturvitenskapelige universitet",
+                "nn": "Noregs teknisk-naturvitskaplege universitet"
+              },
+              "name": [
+                {
+                  "@language": "nn",
+                  "@value": "Noregs teknisk-naturvitskaplege universitet"
+                },
+                {
+                  "@language": "en",
+                  "@value": "Norwegian University of Science and Technology"
+                },
+                {
+                  "@language": "nb",
+                  "@value": "Norges teknisk-naturvitenskapelige universitet"
+                }
+              ]
+            },
+            {
+              "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
+              "type": "Organization",
+              "hasPart": [
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.4.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "ORG",
+                  "labels": {
+                    "nn": "Avdeling for organisasjonsutvikling",
+                    "nb": "Avdeling for organisasjonsutvikling",
+                    "en": "The Organisational Development Department"
+                  },
+                  "name": [
+                    {
+                      "@language": "nn",
+                      "@value": "Avdeling for organisasjonsutvikling"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Avdeling for organisasjonsutvikling"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "The Organisational Development Department"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.2.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "FK",
+                  "labels": {
+                    "nn": "Divisjon for forskings- og kunnskapsressursar",
+                    "nb": "Divisjon forsknings- og kunnskapsressurser",
+                    "en": "The Research and Education Resources Division"
+                  },
+                  "name": [
+                    {
+                      "@language": "nn",
+                      "@value": "Divisjon for forskings- og kunnskapsressursar"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Divisjon forsknings- og kunnskapsressurser"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "The Research and Education Resources Division"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.6.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "KUNDE",
+                  "labels": {
+                    "nn": "Avdeling for kunde og kommunikasjon",
+                    "nb": "Avdeling for kunde og kommunikasjon",
+                    "en": "The Customer and Communication Department"
+                  },
+                  "name": [
+                    {
+                      "@language": "nn",
+                      "@value": "Avdeling for kunde og kommunikasjon"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Avdeling for kunde og kommunikasjon"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "The Customer and Communication Department"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.5.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "VIRK",
+                  "labels": {
+                    "nn": "Avdeling for verksemdstyring",
+                    "nb": "Avdeling for virksomhetsstyring",
+                    "en": "The Corporate Governance Department"
+                  },
+                  "name": [
+                    {
+                      "@language": "nn",
+                      "@value": "Avdeling for verksemdstyring"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Avdeling for virksomhetsstyring"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "The Corporate Governance Department"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "UA",
+                  "labels": {
+                    "nn": "Divisjon for utdanning og administrasjon",
+                    "nb": "Divisjon utdanning og administrasjon",
+                    "en": "The Education and Administration Division"
+                  },
+                  "name": [
+                    {
+                      "@language": "nn",
+                      "@value": "Divisjon for utdanning og administrasjon"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Divisjon utdanning og administrasjon"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "The Education and Administration Division"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"
+                  }
+                },
+                {
+                  "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.3.0.0",
+                  "type": "Organization",
+                  "https://bibsysdev.github.io/src/organization-ontology.ttl#acronym": "DI",
+                  "labels": {
+                    "nn": "Divisjon for data og infrastruktur",
+                    "nb": "Divisjon data og infrastruktur",
+                    "en": "The Organisational Development Department"
+                  },
+                  "name": [
+                    {
+                      "@language": "nn",
+                      "@value": "Divisjon for data og infrastruktur"
+                    },
+                    {
+                      "@language": "nb",
+                      "@value": "Divisjon data og infrastruktur"
+                    },
+                    {
+                      "@language": "en",
+                      "@value": "The Organisational Development Department"
+                    }
+                  ],
+                  "partOf": {
+                    "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"
+                  }
+                }
+              ],
+              "labels": {
+                "nb": "Sikt – Kunnskapssektorens tjenesteleverandør",
+                "en": "Sikt - Norwegian Agency for Shared Services in Education and Research"
+              },
+              "name": [
+                {
+                  "@language": "en",
+                  "@value": "Sikt - Norwegian Agency for Shared Services in Education and Research"
+                },
+                {
+                  "@language": "nb",
+                  "@value": "Sikt – Kunnskapssektorens tjenesteleverandør"
+                }
+              ]
+            }
+          ]
+        },
+        "sort": [
+          1688562314266
+        ]
+      },
+      {
+        "_index": "resources",
+        "_id": "0188d782cbc0-170a7d1e-a9d5-4000-ab7e-082578421592",
+        "_score": null,
+        "_source": {
+          "type": "Publication",
+          "publicationContextUris": [],
+          "@context": {
+            "@vocab": "https://nva.sikt.no/ontology/publication#",
+            "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+            "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+            "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+            "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+            "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+            "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+            "Film": "https://nva.sikt.no/ontology/publication#Film",
+            "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+            "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+            "source": {
+              "@type": "@id"
+            },
+            "approvedBy": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+              },
+              "@type": "@vocab"
+            },
+            "activeFrom": {
+              "@type": "xsd:dateTime"
+            },
+            "activeTo": {
+              "@type": "xsd:dateTime"
+            },
+            "additionalIdentifiers": {
+              "@container": "@set",
+              "@id": "additionalIdentifier"
+            },
+            "affiliations": {
+              "@container": "@set",
+              "@id": "affiliation"
+            },
+            "alternativeTitles": {
+              "@container": "@language",
+              "@id": "alternativeTitle"
+            },
+            "approvals": {
+              "@container": "@set",
+              "@id": "approval"
+            },
+            "approvalStatus": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "architectureOutput": {
+              "@container": "@set",
+              "@id": "architectureOutput"
+            },
+            "associatedArtifacts": {
+              "@container": "@set",
+              "@id": "associatedArtifact"
+            },
+            "compliesWith": {
+              "@container": "@set",
+              "@id": "compliesWith"
+            },
+            "concertProgramme": {
+              "@container": "@set",
+              "@id": "concertProgramme"
+            },
+            "contributors": {
+              "@container": "@set",
+              "@id": "contributor"
+            },
+            "createdDate": {
+              "@type": "xsd:dateTime"
+            },
+            "doi": {
+              "@type": "@id"
+            },
+            "embargoDate": {
+              "@type": "xsd:dateTime"
+            },
+            "from": {
+              "@type": "xsd:dateTime"
+            },
+            "fundings": {
+              "@container": "@set",
+              "@id": "funding"
+            },
+            "handle": {
+              "@type": "@id"
+            },
+            "id": "@id",
+            "indexedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "isbnList": {
+              "@container": "@set",
+              "@id": "isbn"
+            },
+            "labels": {
+              "@container": "@language",
+              "@id": "label"
+            },
+            "language": {
+              "@type": "@id"
+            },
+            "link": {
+              "@type": "@id"
+            },
+            "manifestations": {
+              "@container": "@set",
+              "@id": "manifestation"
+            },
+            "metadataSource": {
+              "@type": "@id"
+            },
+            "modifiedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "musicalWorks": {
+              "@container": "@set",
+              "@id": "musicalWork"
+            },
+            "nameType": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "outputs": {
+              "@container": "@set",
+              "@id": "output"
+            },
+            "ownerAffiliation": {
+              "@type": "@id"
+            },
+            "projects": {
+              "@container": "@set",
+              "@id": "project"
+            },
+            "publishedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "referencedBy": {
+              "@container": "@set",
+              "@id": "referencedBy"
+            },
+            "related": {
+              "@container": "@set",
+              "@id": "related"
+            },
+            "status": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "subjects": {
+              "@container": "@set",
+              "@id": "subject",
+              "@type": "@id"
+            },
+            "tags": {
+              "@container": "@set",
+              "@id": "tag"
+            },
+            "to": {
+              "@type": "xsd:dateTime"
+            },
+            "trackList": {
+              "@container": "@set",
+              "@id": "trackList"
+            },
+            "type": "@type",
+            "venues": {
+              "@container": "@set",
+              "@id": "venue"
+            },
+            "nviType": {
+              "@type": "@vocab",
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              }
+            },
+            "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+            "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+            "publicationContextUris": {
+              "@container": "@set"
+            }
+          },
+          "id": "https://api.dev.nva.aws.unit.no/publication/0188d782cbc0-170a7d1e-a9d5-4000-ab7e-082578421592",
+          "additionalIdentifiers": [
+            {
+              "type": "AdditionalIdentifier",
+              "sourceName": "Cristin",
+              "value": "1052935"
+            }
+          ],
+          "associatedArtifacts": [
+            {
+              "type": "PublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "c7a6cf97-5413-441c-a79c-d1723f399334",
+              "license": "https://rightsstatements.org/page/inc/1.0",
+              "mimeType": "application/pdf",
+              "name": "Skogvoll_2013.pdf",
+              "publishedDate": "2023-06-20T06:34:13.306465Z",
+              "publisherAuthority": false,
+              "size": 1133453,
+              "visibleForNonOwner": true
+            }
+          ],
+          "createdDate": "2013-09-27T08:34:02Z",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "alternativeAbstracts": {},
+            "contributors": [
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Vidar Skogvoll"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              },
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Erni Gustafson"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              }
+            ],
+            "language": "http://lexvo.org/id/iso639-3/nob",
+            "mainTitle": "Vibekes to liv – en utforskning av mulige innganger, - og utganger av en rusmisbrukerkarriere i lys av Akrasia, viljesvakhet og lav selvkontroll.",
+            "publicationDate": {
+              "type": "PublicationDate",
+              "year": "2013"
+            },
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Degree"
+              },
+              "publicationInstance": {
+                "type": "DegreeMaster",
+                "pages": {
+                  "type": "MonographPages",
+                  "illustrated": false
+                },
+                "submittedDate": {
+                  "type": "PublicationDate",
+                  "year": "2013"
+                }
+              }
+            },
+            "tags": [
+              "Selvkontroll / Self-control"
+            ]
+          },
+          "handle": "https://hdl.handle.net/11250/195257",
+          "identifier": "0188d782cbc0-170a7d1e-a9d5-4000-ab7e-082578421592",
+          "modelVersion": "0.20.36",
+          "modifiedDate": "2023-06-20T11:19:37.876565Z",
+          "nviType": "NonNviCandidate",
+          "publishedDate": "2013-09-27T08:34:02Z",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/customer/a768727e-4ecb-41c1-a616-1fec000cac1c",
+            "type": "Organization"
+          },
+          "resourceOwner": {
+            "owner": "krus@1661.0.0.0",
+            "ownerAffiliation": "https://api.sandbox.nva.aws.unit.no/cristin/organization/1661.0.0.0"
+          },
+          "status": "PUBLISHED"
+        },
+        "sort": [
+          1687259977876
+        ]
+      },
+      {
+        "_index": "resources",
+        "_id": "0188d782d4fd-b64de594-8d42-497c-b779-a8fbf4ccfffb",
+        "_score": null,
+        "_source": {
+          "type": "Publication",
+          "publicationContextUris": [],
+          "@context": {
+            "@vocab": "https://nva.sikt.no/ontology/publication#",
+            "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+            "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+            "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+            "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+            "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+            "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+            "Film": "https://nva.sikt.no/ontology/publication#Film",
+            "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+            "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+            "source": {
+              "@type": "@id"
+            },
+            "approvedBy": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+              },
+              "@type": "@vocab"
+            },
+            "activeFrom": {
+              "@type": "xsd:dateTime"
+            },
+            "activeTo": {
+              "@type": "xsd:dateTime"
+            },
+            "additionalIdentifiers": {
+              "@container": "@set",
+              "@id": "additionalIdentifier"
+            },
+            "affiliations": {
+              "@container": "@set",
+              "@id": "affiliation"
+            },
+            "alternativeTitles": {
+              "@container": "@language",
+              "@id": "alternativeTitle"
+            },
+            "approvals": {
+              "@container": "@set",
+              "@id": "approval"
+            },
+            "approvalStatus": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "architectureOutput": {
+              "@container": "@set",
+              "@id": "architectureOutput"
+            },
+            "associatedArtifacts": {
+              "@container": "@set",
+              "@id": "associatedArtifact"
+            },
+            "compliesWith": {
+              "@container": "@set",
+              "@id": "compliesWith"
+            },
+            "concertProgramme": {
+              "@container": "@set",
+              "@id": "concertProgramme"
+            },
+            "contributors": {
+              "@container": "@set",
+              "@id": "contributor"
+            },
+            "createdDate": {
+              "@type": "xsd:dateTime"
+            },
+            "doi": {
+              "@type": "@id"
+            },
+            "embargoDate": {
+              "@type": "xsd:dateTime"
+            },
+            "from": {
+              "@type": "xsd:dateTime"
+            },
+            "fundings": {
+              "@container": "@set",
+              "@id": "funding"
+            },
+            "handle": {
+              "@type": "@id"
+            },
+            "id": "@id",
+            "indexedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "isbnList": {
+              "@container": "@set",
+              "@id": "isbn"
+            },
+            "labels": {
+              "@container": "@language",
+              "@id": "label"
+            },
+            "language": {
+              "@type": "@id"
+            },
+            "link": {
+              "@type": "@id"
+            },
+            "manifestations": {
+              "@container": "@set",
+              "@id": "manifestation"
+            },
+            "metadataSource": {
+              "@type": "@id"
+            },
+            "modifiedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "musicalWorks": {
+              "@container": "@set",
+              "@id": "musicalWork"
+            },
+            "nameType": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "outputs": {
+              "@container": "@set",
+              "@id": "output"
+            },
+            "ownerAffiliation": {
+              "@type": "@id"
+            },
+            "projects": {
+              "@container": "@set",
+              "@id": "project"
+            },
+            "publishedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "referencedBy": {
+              "@container": "@set",
+              "@id": "referencedBy"
+            },
+            "related": {
+              "@container": "@set",
+              "@id": "related"
+            },
+            "status": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "subjects": {
+              "@container": "@set",
+              "@id": "subject",
+              "@type": "@id"
+            },
+            "tags": {
+              "@container": "@set",
+              "@id": "tag"
+            },
+            "to": {
+              "@type": "xsd:dateTime"
+            },
+            "trackList": {
+              "@container": "@set",
+              "@id": "trackList"
+            },
+            "type": "@type",
+            "venues": {
+              "@container": "@set",
+              "@id": "venue"
+            },
+            "nviType": {
+              "@type": "@vocab",
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              }
+            },
+            "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+            "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+            "publicationContextUris": {
+              "@container": "@set"
+            }
+          },
+          "id": "https://api.dev.nva.aws.unit.no/publication/0188d782d4fd-b64de594-8d42-497c-b779-a8fbf4ccfffb",
+          "additionalIdentifiers": [
+            {
+              "type": "AdditionalIdentifier",
+              "sourceName": "Cristin",
+              "value": "1027471"
+            }
+          ],
+          "associatedArtifacts": [
+            {
+              "type": "PublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "c94acd84-2be0-4f60-a3a4-6960d49dd66d",
+              "license": "https://rightsstatements.org/page/inc/1.0",
+              "mimeType": "application/pdf",
+              "name": "Rusmestringsenhetene.pdf",
+              "publishedDate": "2023-06-20T06:34:15.671230Z",
+              "publisherAuthority": false,
+              "size": 1762426,
+              "visibleForNonOwner": true
+            }
+          ],
+          "createdDate": "2014-05-21T07:43:40Z",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "abstract": "Kriminalomsorgen har i samarbeid med spesialisthelsetjenesten opprettet 13 rusmestrings-enheter som skal tilby innsatte i norske fengsler bedre rusbehandling og rehabilitering. Denne studien undersøker iverksettingsstrategien som ble benyttet ved opprettelsen av disse enhetene. Her diskuteres hva slags organisasjonsmodell som ble valgt ved opprettelse av rusmestringsenhetene og hva som påvirket dette valget, samt aktørenes opplevelse av iverksettingsprosessen. Målsetningen med studien er å gi kunnskap som kan bidra til å styrke videre implementering av rusmestringsenhetene.Datagrunnlaget består av skiftelige kilder, observasjon og intervju. I alt er det observert ved fire rusmestringsenheter og 20 personer fra sentralt, regionalt og lokalt nivå er intervjuet. For å tolke og forstå empirien benyttes to teoretiske innfallsvinkler. For å belyse valg av organisasjonsmodell ved rusmestringsenhetene og faktorer som kan ha påvirket dette valget, benytter jeg teori om organisasjonsmoter som er avledet fra ny-institusjonell teori, supplert med rasjonell aktør- og kontigensteori. Selve iverksettingsprosessen analyseres ut fra beslutningsorientert iverksettingsteori.\nResultatene av undersøkelsen viser at organiseringen av rusmestringsenhetene ble politisk bestemt. Sverige og Danmarks satsning på behandling av innsatte rusmiddelmisbrukere synes å ha påvirket Norge til å opprette egne rusmestringsenheter. Norge valgte å organisere behandlingen i rusmestringsenhetene som en importert tjeneste hvor spesialisthelsetjenesten skulle være stedig representert og stå for behandlingen, mens sosialfaglig utdannende ble tilsatt for å utføre rehabiliteringsarbeidet sammen med fengselsbetjentene. Valg av organisasjonsmodell for rusmestringsenhetene forklares med at samfunnet i økende grad oppfatter rusmiddelmisbruk som et helseproblem og at fengslene dermed endret sin interne organisering i tråd med de endringer som hadde skjedd i det ordinære behandlings¬apparatet. Kriminalomsorgens adopsjonen av organisasjons-modell forklares også med egeninteresser hos politisk og administrativ ledelse ved at den valgte organisasjonsmodellen imøtekom politiske føringer om økt tverretatlig og -tverrfaglige samarbeid og bidro til å fremstille politisk og administrativ ledelse som handlingskraftige og tidsriktige. Videre forklares adopsjon av ny organisasjons-modell med at den fylte kriminalomsorgens behov for å innføre en modell som kunne styrke effektiviteten i behandlingen av innsatte rusmiddelmisbrukere.Resultatene fra undersøkelsen viser videre at opprettelsesprosessen gikk fort og at politiske føringer i liten grad ble konkretisert for rusmestringsenhetene. Dette bidro til å skape mye usikkerhet i oppstartsfasen. Prosessen blir i ettertid opplevd som slitsom, men lærerik. Resultatene viser at det har skjedd en målforskyvning fra oppdragsgivers vedtak, både når det gjelder organisering, målsetninger, faglig innhold, bemanning mv. Dels forklares dette med at målene var uklare og styringen svak, og dels med at rusmestringsenhetene er faglig uenige i innholdet i oppdraget. De øremerkede ressursene som ble gitt enhetene ved opprettelse blir vurdert som tilstrekkelige. Resultatene viser imidlertid at kriminalomsorgens regioner og fengselsledere ikke opprettholder ressursbruken. Dette påvirker iverksetting negativt og flere rusmestringsenheter har i dag problemer med å opprettholde driften. Oppdragsgiver ga rusmestringsenhetene et stort lokalt handlingsrom ved utforming av tiltak, samtidig som de valgte organisasjonsmodell og samarbeidspartnere for enhetene. Dette synes å ha begrenset metodeutvikling og læringseffekter under iverksettingen.\n",
+            "alternativeAbstracts": {},
+            "contributors": [
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Janne Henriette Ingarsdotter Helgesen"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              }
+            ],
+            "language": "http://lexvo.org/id/iso639-3/nob",
+            "mainTitle": "Godt begynt er halvt fullendt? : Iverksetting av rusmestringsenheter i norsk kriminalomsorg",
+            "publicationDate": {
+              "type": "PublicationDate",
+              "year": "2013"
+            },
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Degree"
+              },
+              "publicationInstance": {
+                "type": "DegreeMaster",
+                "pages": {
+                  "type": "MonographPages",
+                  "illustrated": false
+                },
+                "submittedDate": {
+                  "type": "PublicationDate",
+                  "year": "2013"
+                }
+              }
+            },
+            "tags": [
+              "Rusmisbruk / Substance abuse",
+              "Rus- og avhengighet / Addiction medicine",
+              "Fengsler / Prisons"
+            ]
+          },
+          "handle": "https://hdl.handle.net/11250/195261",
+          "identifier": "0188d782d4fd-b64de594-8d42-497c-b779-a8fbf4ccfffb",
+          "modelVersion": "0.20.36",
+          "modifiedDate": "2023-06-20T11:19:34.468883Z",
+          "nviType": "NonNviCandidate",
+          "publishedDate": "2014-05-21T07:43:40Z",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/customer/a768727e-4ecb-41c1-a616-1fec000cac1c",
+            "type": "Organization"
+          },
+          "resourceOwner": {
+            "owner": "krus@1661.0.0.0",
+            "ownerAffiliation": "https://api.sandbox.nva.aws.unit.no/cristin/organization/1661.0.0.0"
+          },
+          "status": "PUBLISHED"
+        },
+        "sort": [
+          1687259974468
+        ]
+      },
+      {
+        "_index": "resources",
+        "_id": "0189254ff693-3a1388dd-2192-4e60-9c76-dc8a82817f03",
+        "_score": null,
+        "_source": {
+          "type": "Publication",
+          "publicationContextUris": [],
+          "@context": {
+            "@vocab": "https://nva.sikt.no/ontology/publication#",
+            "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+            "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+            "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+            "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+            "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+            "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+            "Film": "https://nva.sikt.no/ontology/publication#Film",
+            "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+            "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+            "source": {
+              "@type": "@id"
+            },
+            "approvedBy": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+              },
+              "@type": "@vocab"
+            },
+            "activeFrom": {
+              "@type": "xsd:dateTime"
+            },
+            "activeTo": {
+              "@type": "xsd:dateTime"
+            },
+            "additionalIdentifiers": {
+              "@container": "@set",
+              "@id": "additionalIdentifier"
+            },
+            "affiliations": {
+              "@container": "@set",
+              "@id": "affiliation"
+            },
+            "alternativeTitles": {
+              "@container": "@language",
+              "@id": "alternativeTitle"
+            },
+            "approvals": {
+              "@container": "@set",
+              "@id": "approval"
+            },
+            "approvalStatus": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "architectureOutput": {
+              "@container": "@set",
+              "@id": "architectureOutput"
+            },
+            "associatedArtifacts": {
+              "@container": "@set",
+              "@id": "associatedArtifact"
+            },
+            "compliesWith": {
+              "@container": "@set",
+              "@id": "compliesWith"
+            },
+            "concertProgramme": {
+              "@container": "@set",
+              "@id": "concertProgramme"
+            },
+            "contributors": {
+              "@container": "@set",
+              "@id": "contributor"
+            },
+            "createdDate": {
+              "@type": "xsd:dateTime"
+            },
+            "doi": {
+              "@type": "@id"
+            },
+            "embargoDate": {
+              "@type": "xsd:dateTime"
+            },
+            "from": {
+              "@type": "xsd:dateTime"
+            },
+            "fundings": {
+              "@container": "@set",
+              "@id": "funding"
+            },
+            "handle": {
+              "@type": "@id"
+            },
+            "id": "@id",
+            "indexedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "isbnList": {
+              "@container": "@set",
+              "@id": "isbn"
+            },
+            "labels": {
+              "@container": "@language",
+              "@id": "label"
+            },
+            "language": {
+              "@type": "@id"
+            },
+            "link": {
+              "@type": "@id"
+            },
+            "manifestations": {
+              "@container": "@set",
+              "@id": "manifestation"
+            },
+            "metadataSource": {
+              "@type": "@id"
+            },
+            "modifiedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "musicalWorks": {
+              "@container": "@set",
+              "@id": "musicalWork"
+            },
+            "nameType": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "outputs": {
+              "@container": "@set",
+              "@id": "output"
+            },
+            "ownerAffiliation": {
+              "@type": "@id"
+            },
+            "projects": {
+              "@container": "@set",
+              "@id": "project"
+            },
+            "publishedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "referencedBy": {
+              "@container": "@set",
+              "@id": "referencedBy"
+            },
+            "related": {
+              "@container": "@set",
+              "@id": "related"
+            },
+            "status": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "subjects": {
+              "@container": "@set",
+              "@id": "subject",
+              "@type": "@id"
+            },
+            "tags": {
+              "@container": "@set",
+              "@id": "tag"
+            },
+            "to": {
+              "@type": "xsd:dateTime"
+            },
+            "trackList": {
+              "@container": "@set",
+              "@id": "trackList"
+            },
+            "type": "@type",
+            "venues": {
+              "@container": "@set",
+              "@id": "venue"
+            },
+            "nviType": {
+              "@type": "@vocab",
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              }
+            },
+            "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+            "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+            "publicationContextUris": {
+              "@container": "@set"
+            }
+          },
+          "id": "https://api.dev.nva.aws.unit.no/publication/0189254ff693-3a1388dd-2192-4e60-9c76-dc8a82817f03",
+          "associatedArtifacts": [
+            {
+              "type": "PublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "9e942761-2e3e-40b7-b826-39855d6ff11e",
+              "mimeType": "application/pdf",
+              "name": "Christian Nepstad.pdf",
+              "publishedDate": "2023-07-05T09:09:04.787715Z",
+              "publisherAuthority": false,
+              "size": 1313535,
+              "visibleForNonOwner": true
+            }
+          ],
+          "createdDate": "2020-10-23T07:25:27Z",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "abstract": "Norsk og nordisk forskning har i liten grad hatt fokus på geografisk forankrede lokale kulturer irelasjontilutdannelse,samtidigsomatungdomsforskningharavflereværtkritisertforen ikke-anerkjent metrosentrisme.Pådennemåtenforsvinnerstedetfraanalysenogdet urbane livet tas ukritisk som utgangspunkt for generalisering av ungdommer på tvers av geografiske forskjeller (Cuervo & Wyn, 2017; Farrugia, 2014; Horrigmo, 2015; Paulgaard, 2017). I studier av ungdom og rural migrasjon har ofte fokuset vært på dem som flytter, og ikke dem som blir, samtidig som at kjønnsaspektet i stor grad har vært fraværende. (Faber et al., 2015; Rye,2009).Gjennom kvalitative intervjuer av åtte gutter fra ei bygd i indre Agder har jeg derfor utforsket stedetsbetydning forguttenes forlivsvalg,yrkesvalgogselvforståelse. Studienhargitten innsikt i hva disse guttene selv legger til grunn for sine valg og hvordan strukturer som sted og klasse har innvirkning på disse valgene. Studiens tydeligste funn er stedets viktige rolle i det som utgjør de grunnleggende rammene for hvordan guttene forstår seg selv og hvordan de ser for seg framtiden. Selv om guttene fremstår somrefleksiverasjonelleaktørerisittegetliverdettydeligatstedetformer,begrenserog muliggjør både deres selvforståelse og viktige livsvalg. Bildet av bygdegutter som blir værende påbygdasommarginalisertetapereliknerimidlertidlitepådetbildetkommerfram idenne studien. Guttene fremstår ikke som passive og begrenset, men som aktivt handlende for å sikre seg den framtiden de ønsker. Det er tydelig at guttene som vil bo på bygda aktivt velger bort et liv i byen, fordi de mener at bygda gir de beste rammene for det de oppfatter som det gode liv.\n",
+            "alternativeAbstracts": {},
+            "contributors": [
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Christian Nepstad"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              }
+            ],
+            "description": "Master's thesis in Social science (SV505)\n",
+            "language": "http://lexvo.org/id/iso639-3/nob",
+            "mainTitle": "Bygda eller livet! : En kvalitativ studie av stedets betydning for livsvalg og selvforståelse hos unge gutter i indre Agder",
+            "publicationDate": {
+              "type": "PublicationDate",
+              "year": "2020"
+            },
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Degree",
+                "publisher": {
+                  "type": "UnconfirmedPublisher",
+                  "name": "University of Agder",
+                  "valid": true
+                }
+              },
+              "publicationInstance": {
+                "type": "DegreeMaster",
+                "pages": {
+                  "type": "MonographPages",
+                  "illustrated": false,
+                  "pages": "111"
+                },
+                "submittedDate": {
+                  "type": "PublicationDate",
+                  "year": "2020"
+                }
+              }
+            },
+            "tags": [
+              "SV505"
+            ]
+          },
+          "handle": "https://hdl.handle.net/11250/2684657",
+          "identifier": "0189254ff693-3a1388dd-2192-4e60-9c76-dc8a82817f03",
+          "modelVersion": "0.20.36",
+          "nviType": "NonNviCandidate",
+          "publishedDate": "2020-10-23T07:25:27Z",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/customer/b4497570-2903-49a2-9c2a-d6ab8b0eacc2",
+            "type": "Organization"
+          },
+          "resourceOwner": {
+            "owner": "nve@5948.0.0.0",
+            "ownerAffiliation": "https://api.sandbox.nva.aws.unit.no/cristin/organization/5948.0.0.0"
+          },
+          "rightsHolder": "© 2020 Christian Nepstad",
+          "status": "PUBLISHED"
+        },
+        "sort": [
+          -9223372036854775808
+        ]
+      },
+      {
+        "_index": "resources",
+        "_id": "018925529e29-cdc62bf8-e511-4fd6-a6a7-cc49c407b6e6",
+        "_score": null,
+        "_source": {
+          "type": "Publication",
+          "publicationContextUris": [],
+          "@context": {
+            "@vocab": "https://nva.sikt.no/ontology/publication#",
+            "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+            "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+            "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+            "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+            "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+            "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+            "Film": "https://nva.sikt.no/ontology/publication#Film",
+            "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+            "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+            "source": {
+              "@type": "@id"
+            },
+            "approvedBy": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+              },
+              "@type": "@vocab"
+            },
+            "activeFrom": {
+              "@type": "xsd:dateTime"
+            },
+            "activeTo": {
+              "@type": "xsd:dateTime"
+            },
+            "additionalIdentifiers": {
+              "@container": "@set",
+              "@id": "additionalIdentifier"
+            },
+            "affiliations": {
+              "@container": "@set",
+              "@id": "affiliation"
+            },
+            "alternativeTitles": {
+              "@container": "@language",
+              "@id": "alternativeTitle"
+            },
+            "approvals": {
+              "@container": "@set",
+              "@id": "approval"
+            },
+            "approvalStatus": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "architectureOutput": {
+              "@container": "@set",
+              "@id": "architectureOutput"
+            },
+            "associatedArtifacts": {
+              "@container": "@set",
+              "@id": "associatedArtifact"
+            },
+            "compliesWith": {
+              "@container": "@set",
+              "@id": "compliesWith"
+            },
+            "concertProgramme": {
+              "@container": "@set",
+              "@id": "concertProgramme"
+            },
+            "contributors": {
+              "@container": "@set",
+              "@id": "contributor"
+            },
+            "createdDate": {
+              "@type": "xsd:dateTime"
+            },
+            "doi": {
+              "@type": "@id"
+            },
+            "embargoDate": {
+              "@type": "xsd:dateTime"
+            },
+            "from": {
+              "@type": "xsd:dateTime"
+            },
+            "fundings": {
+              "@container": "@set",
+              "@id": "funding"
+            },
+            "handle": {
+              "@type": "@id"
+            },
+            "id": "@id",
+            "indexedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "isbnList": {
+              "@container": "@set",
+              "@id": "isbn"
+            },
+            "labels": {
+              "@container": "@language",
+              "@id": "label"
+            },
+            "language": {
+              "@type": "@id"
+            },
+            "link": {
+              "@type": "@id"
+            },
+            "manifestations": {
+              "@container": "@set",
+              "@id": "manifestation"
+            },
+            "metadataSource": {
+              "@type": "@id"
+            },
+            "modifiedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "musicalWorks": {
+              "@container": "@set",
+              "@id": "musicalWork"
+            },
+            "nameType": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "outputs": {
+              "@container": "@set",
+              "@id": "output"
+            },
+            "ownerAffiliation": {
+              "@type": "@id"
+            },
+            "projects": {
+              "@container": "@set",
+              "@id": "project"
+            },
+            "publishedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "referencedBy": {
+              "@container": "@set",
+              "@id": "referencedBy"
+            },
+            "related": {
+              "@container": "@set",
+              "@id": "related"
+            },
+            "status": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "subjects": {
+              "@container": "@set",
+              "@id": "subject",
+              "@type": "@id"
+            },
+            "tags": {
+              "@container": "@set",
+              "@id": "tag"
+            },
+            "to": {
+              "@type": "xsd:dateTime"
+            },
+            "trackList": {
+              "@container": "@set",
+              "@id": "trackList"
+            },
+            "type": "@type",
+            "venues": {
+              "@container": "@set",
+              "@id": "venue"
+            },
+            "nviType": {
+              "@type": "@vocab",
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              }
+            },
+            "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+            "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+            "publicationContextUris": {
+              "@container": "@set"
+            }
+          },
+          "id": "https://api.dev.nva.aws.unit.no/publication/018925529e29-cdc62bf8-e511-4fd6-a6a7-cc49c407b6e6",
+          "associatedArtifacts": [
+            {
+              "type": "PublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "6fae41b8-d755-4920-a7ff-26b8eb352fa9",
+              "mimeType": "application/pdf",
+              "name": "no.uia:inspera:96137193:9764673.pdf",
+              "publishedDate": "2023-07-05T09:11:58.761461Z",
+              "publisherAuthority": false,
+              "size": 9808564,
+              "visibleForNonOwner": true
+            }
+          ],
+          "createdDate": "2022-04-20T16:23:12Z",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "abstract": "null\nHow do selected environmental factors affect haul-out behavior of harbor seals in Skagerrak and in northern Norway? Does the probability of hauling out differ between the geographical areas?\n",
+            "alternativeAbstracts": {},
+            "contributors": [
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Nina Hille Bringsdal"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              },
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Martin Biuw Carla Freita"
+                },
+                "role": {
+                  "type": "Advisor"
+                }
+              }
+            ],
+            "language": "http://lexvo.org/id/iso639-3/eng",
+            "mainTitle": "Haul-out Behavior of Harbor Seals (Phoca vitulina) along the Norwegian Coast",
+            "publicationDate": {
+              "type": "PublicationDate",
+              "year": "2021"
+            },
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Degree",
+                "publisher": {
+                  "type": "UnconfirmedPublisher",
+                  "name": "University of Agder",
+                  "valid": true
+                }
+              },
+              "publicationInstance": {
+                "type": "DegreeMaster",
+                "pages": {
+                  "type": "MonographPages",
+                  "illustrated": false
+                },
+                "submittedDate": {
+                  "type": "PublicationDate",
+                  "year": "2021"
+                }
+              }
+            }
+          },
+          "handle": "https://hdl.handle.net/11250/2991720",
+          "identifier": "018925529e29-cdc62bf8-e511-4fd6-a6a7-cc49c407b6e6",
+          "modelVersion": "0.20.36",
+          "nviType": "NonNviCandidate",
+          "publishedDate": "2022-04-20T16:23:12Z",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/customer/b4497570-2903-49a2-9c2a-d6ab8b0eacc2",
+            "type": "Organization"
+          },
+          "resourceOwner": {
+            "owner": "nve@5948.0.0.0",
+            "ownerAffiliation": "https://api.sandbox.nva.aws.unit.no/cristin/organization/5948.0.0.0"
+          },
+          "status": "PUBLISHED"
+        },
+        "sort": [
+          -9223372036854775808
+        ]
+      },
+      {
+        "_index": "resources",
+        "_id": "01892552af57-2433c793-c4fc-41ff-8d03-faa7a574d687",
+        "_score": null,
+        "_source": {
+          "type": "Publication",
+          "publicationContextUris": [],
+          "@context": {
+            "@vocab": "https://nva.sikt.no/ontology/publication#",
+            "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+            "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+            "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+            "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+            "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+            "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+            "Film": "https://nva.sikt.no/ontology/publication#Film",
+            "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+            "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+            "source": {
+              "@type": "@id"
+            },
+            "approvedBy": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+              },
+              "@type": "@vocab"
+            },
+            "activeFrom": {
+              "@type": "xsd:dateTime"
+            },
+            "activeTo": {
+              "@type": "xsd:dateTime"
+            },
+            "additionalIdentifiers": {
+              "@container": "@set",
+              "@id": "additionalIdentifier"
+            },
+            "affiliations": {
+              "@container": "@set",
+              "@id": "affiliation"
+            },
+            "alternativeTitles": {
+              "@container": "@language",
+              "@id": "alternativeTitle"
+            },
+            "approvals": {
+              "@container": "@set",
+              "@id": "approval"
+            },
+            "approvalStatus": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "architectureOutput": {
+              "@container": "@set",
+              "@id": "architectureOutput"
+            },
+            "associatedArtifacts": {
+              "@container": "@set",
+              "@id": "associatedArtifact"
+            },
+            "compliesWith": {
+              "@container": "@set",
+              "@id": "compliesWith"
+            },
+            "concertProgramme": {
+              "@container": "@set",
+              "@id": "concertProgramme"
+            },
+            "contributors": {
+              "@container": "@set",
+              "@id": "contributor"
+            },
+            "createdDate": {
+              "@type": "xsd:dateTime"
+            },
+            "doi": {
+              "@type": "@id"
+            },
+            "embargoDate": {
+              "@type": "xsd:dateTime"
+            },
+            "from": {
+              "@type": "xsd:dateTime"
+            },
+            "fundings": {
+              "@container": "@set",
+              "@id": "funding"
+            },
+            "handle": {
+              "@type": "@id"
+            },
+            "id": "@id",
+            "indexedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "isbnList": {
+              "@container": "@set",
+              "@id": "isbn"
+            },
+            "labels": {
+              "@container": "@language",
+              "@id": "label"
+            },
+            "language": {
+              "@type": "@id"
+            },
+            "link": {
+              "@type": "@id"
+            },
+            "manifestations": {
+              "@container": "@set",
+              "@id": "manifestation"
+            },
+            "metadataSource": {
+              "@type": "@id"
+            },
+            "modifiedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "musicalWorks": {
+              "@container": "@set",
+              "@id": "musicalWork"
+            },
+            "nameType": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "outputs": {
+              "@container": "@set",
+              "@id": "output"
+            },
+            "ownerAffiliation": {
+              "@type": "@id"
+            },
+            "projects": {
+              "@container": "@set",
+              "@id": "project"
+            },
+            "publishedDate": {
+              "@type": "xsd:dateTime"
+            },
+            "referencedBy": {
+              "@container": "@set",
+              "@id": "referencedBy"
+            },
+            "related": {
+              "@container": "@set",
+              "@id": "related"
+            },
+            "status": {
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              },
+              "@type": "@vocab"
+            },
+            "subjects": {
+              "@container": "@set",
+              "@id": "subject",
+              "@type": "@id"
+            },
+            "tags": {
+              "@container": "@set",
+              "@id": "tag"
+            },
+            "to": {
+              "@type": "xsd:dateTime"
+            },
+            "trackList": {
+              "@container": "@set",
+              "@id": "trackList"
+            },
+            "type": "@type",
+            "venues": {
+              "@container": "@set",
+              "@id": "venue"
+            },
+            "nviType": {
+              "@type": "@vocab",
+              "@context": {
+                "@vocab": "https://nva.sikt.no/ontology/publication#"
+              }
+            },
+            "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+            "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+            "publicationContextUris": {
+              "@container": "@set"
+            }
+          },
+          "id": "https://api.dev.nva.aws.unit.no/publication/01892552af57-2433c793-c4fc-41ff-8d03-faa7a574d687",
+          "associatedArtifacts": [
+            {
+              "type": "PublishedFile",
+              "administrativeAgreement": false,
+              "identifier": "de47f7da-5c30-4a32-9601-cc73eb4f654f",
+              "mimeType": "application/pdf",
+              "name": "RajalaSatu.pdf",
+              "publishedDate": "2023-07-05T09:12:03.159015Z",
+              "publisherAuthority": false,
+              "size": 685749,
+              "visibleForNonOwner": true
+            }
+          ],
+          "createdDate": "2019-12-12T09:54:13Z",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "abstract": "Abreak firstfrom TraditionalPublicAdministration(TPA)and later NewPublicManagement(NPM)has graduallyofferednewanglestothegovernance.Forinstance,Moorecreatedan analoguetotheprivate valuecreation,andasaresult,the ideologyofpublicvaluecreation has emergedworldwide.Sincethen, scholarshavedevelopedaconceptualunderstandingofpublicvalue.ComparedtotheNPMpublicvalue management embraces post-competitive achievements and broader governmental goals. Yet, the empirical research on public value management, especially in the Finnish context, is rather unknown.This study examines how a public organization defines the process of public value creation in relation to the government program.The significance of public value arises when discussing health and social services. For this purpose, a case study on the preparation of the regional government, social and health services reform inPirkanmaa was conducted.Thereformofregionalgovernment,socialandhealthserviceswasan extensivereformprogramthatSipilä’sGovernmentintroducedin2015.Thereformproposalpurposesof removing the duties from municipalities to the new governance units –the counties –that are responsible for arrangingservicestothelargerpopulationbase.Thepreparationofthereformhaspartlydelegatedfrom centralgovernancetotheRegionalCouncils.InPirkanmaathepreparationprogressedwellinmutual agreement. Forthis, among other reasons, Pirkanmaa is a compelling research object.Thedesignofthisstudyutilizesqualitativeresearchmethods.Bothprimaryandsecondarydatawere collectedtogainin-depthunderstanding.Theprimarydatawascollectedinterviewingsevenprofessionals withdifferentexpertiseatthecaseorganization,Pirkanmaa2021.Todecreaseinterviewbiasessecondary datawasgathered.Theanalysisofthedatawascontentdriven.Atable,whichidentifieselementsthat contribute to the public value creation, was formulated based on the analysis.Theresearchfindingsimplicatethatthepublicvaluecreationhasbeenunintentional,aself-guiding process.If the reform is implementedsuccessfully, it can be expectedthat the process feedvalue creation to the public, which fosters not only the performance of the public organization but also the citizens’ well-being andregionaldevelopment.Thesefindingsneverthelessarespecifictothetimeandplace.Sincethe Government suddenly resigned prior the parliamentary elections the preparation of the reform was run down. Despite the efforts in Pirkanmaa, it is unsure whether the potential value can be realized as planned. Overall, thisstudycontributestotheliteratureofpublicvaluemanagement,andthusservesasabasisforfurther research in the Finnish context.Keywords: PublicValueManagement;ValueCo-creation;MeasuringPublicValue;RegionalGovernment, HealthandSocialServicesReform;RegionalStudies;Maakuntauudistus;Sosiaali-jaterveydenhuollon uudistus\n",
+            "alternativeAbstracts": {},
+            "contributors": [
+              {
+                "type": "Contributor",
+                "correspondingAuthor": false,
+                "identity": {
+                  "type": "Identity",
+                  "name": "Satu Rajala"
+                },
+                "role": {
+                  "type": "Creator"
+                }
+              }
+            ],
+            "description": "Master's thesis Innovative governance and public management ME523 - University of Agder 2019\n",
+            "language": "http://lexvo.org/id/iso639-3/eng",
+            "mainTitle": "The Relationship between Public Value and Change : Case Study on Public Value Creation in Relation to the Regional Government, Health and Social Services Reform in Pirkanmaa",
+            "publicationDate": {
+              "type": "PublicationDate",
+              "year": "2019"
+            },
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Degree",
+                "publisher": {
+                  "type": "UnconfirmedPublisher",
+                  "name": "Universitetet i Agder ; University of Agder",
+                  "valid": true
+                }
+              },
+              "publicationInstance": {
+                "type": "DegreeMaster",
+                "pages": {
+                  "type": "MonographPages",
+                  "illustrated": false
+                },
+                "submittedDate": {
+                  "type": "PublicationDate",
+                  "year": "2019"
+                }
+              }
+            },
+            "tags": [
+              "Health and Social Services Reform",
+              "Maakuntauudistus",
+              "Regional Government",
+              "ME523",
+              "Public Value Management",
+              "Measuring Public Value",
+              "Value Co-creation",
+              "Sosiaali-ja terveydenhuollon uudistus",
+              "Regional Studies"
+            ]
+          },
+          "handle": "https://hdl.handle.net/11250/2632912",
+          "identifier": "01892552af57-2433c793-c4fc-41ff-8d03-faa7a574d687",
+          "modelVersion": "0.20.36",
+          "nviType": "NonNviCandidate",
+          "publishedDate": "2019-12-12T09:54:13Z",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/customer/b4497570-2903-49a2-9c2a-d6ab8b0eacc2",
+            "type": "Organization"
+          },
+          "resourceOwner": {
+            "owner": "nve@5948.0.0.0",
+            "ownerAffiliation": "https://api.sandbox.nva.aws.unit.no/cristin/organization/5948.0.0.0"
+          },
+          "status": "PUBLISHED"
+        },
+        "sort": [
+          -9223372036854775808
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This is a draft to show how to use search_after.
Use of search_after is not compatible with pagination variable `from`, cause `from` in this case it the last retrieved index document.

`searchAfter` should be sent as query param with the sort value of the last hit from response. 