### PR TITLE
filter for imported import candidates by user

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/constants/ApplicationConstants.java
+++ b/search-commons/src/main/java/no/unit/nva/search/constants/ApplicationConstants.java
@@ -5,8 +5,10 @@ import java.util.List;
 import java.util.stream.Stream;
 import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.core.Environment;
-    import org.opensearch.search.aggregations.AbstractAggregationBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.search.aggregations.AbstractAggregationBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 
@@ -42,7 +44,8 @@ public final class ApplicationConstants {
                                   "importStatus.candidateStatus.keyword"),
         generateSimpleAggregation("publicationYear", "publicationYear.keyword"),
         generateObjectLabelsAggregation("organizations"),
-        generateSimpleAggregation("collaborationType", "collaborationType.keyword")
+        generateSimpleAggregation("collaborationType", "collaborationType.keyword"),
+        generateImportedByUserAggregation()
     );
 
     public static final TermsAggregationBuilder TYPE_TERMS_AGGREGATION = generateSimpleAggregation("type",
@@ -92,6 +95,15 @@ public final class ApplicationConstants {
                    .terms(term)
                    .field(field)
                    .size(DEFAULT_AGGREGATION_SIZE);
+    }
+
+    private static FilterAggregationBuilder generateImportedByUserAggregation() {
+        return new FilterAggregationBuilder("importedByUser",
+                                            new TermQueryBuilder("importStatus.candidateStatus.keyword", "IMPORTED"))
+            .subAggregation(AggregationBuilders
+                                .terms("importStatus.setBy")
+                                .field("importStatus.setBy.keyword")
+                                .size(DEFAULT_AGGREGATION_SIZE));
     }
 
     private static NestedAggregationBuilder generateTypeAggregation() {

--- a/search-commons/src/test/java/no/unit/nva/search/OpensearchTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/OpensearchTest.java
@@ -209,7 +209,9 @@ public class OpensearchTest {
         @Test
         void shouldReturnCorrectAggregationsForImportCandidates()
             throws InterruptedException, ApiGatewayException {
-            addDocumentsToIndex("imported_candidate_from_index.json", "not_imported_candidate_from_index.json");
+            addDocumentsToIndex("imported_candidate_from_index.json",
+                                        "not_imported_candidate_from_index.json",
+                                       "not_applicable_import_candidate_from_index.json");
 
             var query = queryWithTermAndAggregation(SEARCH_ALL, IMPORT_CANDIDATES_AGGREGATIONS);
 

--- a/search-commons/src/test/resources/not_applicable_import_candidate_from_index.json
+++ b/search-commons/src/test/resources/not_applicable_import_candidate_from_index.json
@@ -1,8 +1,8 @@
 {
   "importStatus": {
-    "candidateStatus": "IMPORTED",
+    "candidateStatus": "NOT_APPLICABLE",
     "modifiedDate": "2023-06-28T14:39:45.353154Z",
-    "setBy": "someUser"
+    "setBy": "user123"
   },
   "collaborationType": "NonCollaborative",
   "journal": {


### PR DESCRIPTION
Generates following aggregation:

```
"importedByUser": {
		"docCount": 1,
		"importStatus.setBy": {
			"docCountErrorUpperBound": 0,
			"sumOtherDocCount": 0,
			"buckets": [{
				"key": "someUser",
				"docCount": 1
			}]
		}
	}
```

Aggregation shows number of importCandidates with importStatus `IMPORTED` aggregated by user