### PR TITLE
NP-46865-security-headers

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ javers = { strictly = '6.5.1' }
 junit = { strictly = '5.10.0' }
 log4j = { strictly = '2.23.0' }
 mockito = { strictly = '4.2.0' }
-nvaCommons = { prefer = '1.39.1' }
+nvaCommons = { prefer = '1.39.3' }
 open-csv = { strictly = '5.8' }
 openSearchRestClient = { strictly = '2.9.0' }
 opensearch = { strictly = '2.6.0' }


### PR DESCRIPTION
ApiGateway handler i NVA-commons inneholder nå ekstra security-headers.
Sett over at det som brukes av swagger dokumentasjonen benytter ApiGatewayHandler