### PR TITLE
build: Set fixed version for Spotless plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation group: 'nebula.lint', name: 'nebula.lint.gradle.plugin', version: '17.8.0'
     implementation group: 'org.jacoco', name: 'org.jacoco.core', version: '0.8.7'
     implementation group: 'org.jacoco', name: 'org.jacoco.report', version: '0.8.7'
-    implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: 'latest.release'
+    implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '7.0.1'
 }
 
 group = 'com.github.bibsysdev'


### PR DESCRIPTION
This sets a fixed version instead of `latest` for the formatting plugin, as there is no reason to use a dynamic version range here.