### PR TITLE
renaming cognito_uri to cognito_host

### DIFF
--- a/search-commons/build.gradle
+++ b/search-commons/build.gradle
@@ -42,7 +42,7 @@ test {
     environment "ALLOWED_ORIGIN", "*"
     environment "API_HOST", "localhost"
     environment "BACKEND_CLIENT_SECRET_NAME", "secret"
-    environment "COGNITO_URI", "https://example.org"
+    environment "COGNITO_HOST", "https://example.org"
     environment "EXPORT_SEARCH_RESULTS_SIZE", "100"
     environment "IDENTITY_SERVICE_SECRET_KEY", "secretKey"
     environment "IDENTITY_SERVICE_SECRET_NAME", "secretName"

--- a/search-handlers/build.gradle
+++ b/search-handlers/build.gradle
@@ -37,7 +37,7 @@ test {
     environment "AWS_REGION", "eu-west-1"
     environment "LARGE_API_RESPONSES_BUCKET", "some-bucket"
     environment "ALLOWED_ORIGIN", "*"
-    environment "COGNITO_URI", "https://example.org"
+    environment "COGNITO_HOST", "https://example.org"
     environment "API_HOST", "https://example.org"
     environment "SEARCH_INFRASTRUCTURE_API_URI", "https://example.org"
     environment "SEARCH_INFRASTRUCTURE_AUTH_URI", "https://example.org"

--- a/template.yaml
+++ b/template.yaml
@@ -15,7 +15,7 @@ Globals:
       Variables:
         SEARCH_INFRASTRUCTURE_API_URI: !Ref SearchInfrastructureApiUri
         SEARCH_INFRASTRUCTURE_AUTH_URI: !Ref SearchInfrastructureAuthUri
-        COGNITO_URI: !Ref CognitoUri
+        COGNITO_HOST: !Ref CognitoUri
         API_HOST: !Sub 'api.${CustomDomain}'
         LARGE_API_RESPONSES_BUCKET: !Ref LargeApiResponsesBucketName
   Api:
@@ -255,7 +255,7 @@ Resources:
       Environment:
         Variables:
           ALLOWED_ORIGIN: !Ref AllowedOrigins
-          COGNITO_URI: !Ref CognitoUri
+          COGNITO_HOST: !Ref CognitoUri
           BACKEND_CLIENT_SECRET_NAME: 'BackendCognitoClientCredentials'
       Events:
         GetTickets:
@@ -331,7 +331,7 @@ Resources:
       Environment:
         Variables:
           ALLOWED_ORIGIN: !Ref AllowedOrigins
-          COGNITO_URI: !Ref CognitoUri
+          COGNITO_HOST: !Ref CognitoUri
       Events:
         GetResources:
           Type: Api
@@ -357,7 +357,7 @@ Resources:
       Environment:
         Variables:
           ALLOWED_ORIGIN: !Ref AllowedOrigins
-          COGNITO_URI: !Ref CognitoUri
+          COGNITO_HOST: !Ref CognitoUri
       Events:
         GetResources:
           Type: Api


### PR DESCRIPTION
Rydder opp i loggene i search-api.


Endrer navner til COGNITO_URI til COGNITO_HOST slik at denne logmeldingen ikke logges overalt:

ERROR n.c.c.Environment:34 - Environment variable not set: COGNITO_HOST

Verdien til Cognito hosten er egentlig en URI og ikke en HOST :)

