### PR TITLE
ci: Update buildspec

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -5,7 +5,15 @@ phases:
     runtime-versions:
       java: corretto21
     commands:
-      - pip3 install aws-sam-cli -U
+      - echo "Checking if AWS SAM CLI is installed"
+      - |
+        if command -v sam >/dev/null 2>&1; then
+          echo "AWS SAM CLI is already installed";
+          sam --version;
+        else
+          echo "AWS SAM CLI is not installed, installing now";
+          pip3 install aws-sam-cli
+        fi
   build:
     commands:
       - sam build

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -1,5 +1,14 @@
 version: 0.2
 
+env:
+  variables:
+    GRADLE_USER_HOME: '/root/.gradle'
+    SAM_CLI_TELEMETRY: "0"
+
+cache:
+  paths:
+    - '/root/.gradle/caches/**/*'
+
 phases:
   install:
     runtime-versions:

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -17,9 +17,9 @@ phases:
   build:
     commands:
       - sam build
-      - sam package --s3-bucket $S3_BUCKET --output-template-file packaged_raw.yaml
   post_build:
     commands:
+      - sam package --s3-bucket $S3_BUCKET --output-template-file packaged_raw.yaml
       # Use timestamp to force update of ApiGatewayCreateDeploymentCustomResource
       - BUILD_TIMESTAMP=$(date '+%s')
       - envsubst '${BUILD_TIMESTAMP}' < packaged_raw.yaml > packaged.yaml


### PR DESCRIPTION
Improves build time significantly in most cases by using S3 to cache Gradle files.

Other changes:
- Disables SAM CLI telemetry
- Moves packaging to separate phase for visibility
- Skips re-installing SAM CLI if present