### PR TITLE
now metadataPrefix is always checked and used correctly

### DIFF
--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ListMetadataFormats.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ListMetadataFormats.java
@@ -10,7 +10,6 @@ import org.openarchives.oai.pmh.v2.ObjectFactory;
 import org.openarchives.oai.pmh.v2.VerbType;
 
 public class ListMetadataFormats {
-  private static final String OAI_DC_METADATA_PREFIX = "oai-dc";
 
   public ListMetadataFormats() {}
 
@@ -23,7 +22,7 @@ public class ListMetadataFormats {
     var listMetadataFormatsType = objectFactory.createListMetadataFormatsType();
 
     var metadataFormatType = objectFactory.createMetadataFormatType();
-    metadataFormatType.setMetadataPrefix(OAI_DC_METADATA_PREFIX);
+    metadataFormatType.setMetadataPrefix(MetadataPrefix.OAI_DC.getPrefix());
     metadataFormatType.setSchema(getSchemaLocation(Namespaces.OAI_DC));
     metadataFormatType.setMetadataNamespace(Namespaces.OAI_DC);
 

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ListRecords.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ListRecords.java
@@ -8,6 +8,7 @@ import static no.unit.nva.search.common.enums.PublicationStatus.PUBLISHED;
 import static no.unit.nva.search.common.enums.PublicationStatus.PUBLISHED_METADATA;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.html.HtmlEscapers;
 import jakarta.xml.bind.JAXBElement;
 import java.math.BigInteger;
 import java.time.ZonedDateTime;
@@ -22,6 +23,7 @@ import no.unit.nva.search.resource.ResourceSort;
 import no.unit.nva.search.resource.SimplifiedMutator;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import org.openarchives.oai.pmh.v2.ListRecordsType;
+import org.openarchives.oai.pmh.v2.OAIPMHerrorcodeType;
 import org.openarchives.oai.pmh.v2.OAIPMHtype;
 import org.openarchives.oai.pmh.v2.ObjectFactory;
 import org.openarchives.oai.pmh.v2.RecordType;
@@ -50,9 +52,22 @@ public class ListRecords {
   }
 
   public JAXBElement<OAIPMHtype> listRecords(OaiPmhRequest request) {
-    var searchResult = performSearch(request);
     var objectFactory = new ObjectFactory();
+
     var oaiResponse = createBaseResponse(request, objectFactory);
+    try {
+      var ignored =
+          nonNull(request.getMetadataPrefix())
+              ? MetadataPrefix.fromPrefix(request.getMetadataPrefix())
+              : MetadataPrefix.OAI_DC;
+    } catch (MetadataPrefixNotSupportedException e) {
+      var errorType = objectFactory.createOAIPMHerrorType();
+      errorType.setCode(OAIPMHerrorcodeType.CANNOT_DISSEMINATE_FORMAT);
+      errorType.setValue(HtmlEscapers.htmlEscaper().escape(request.getMetadataPrefix()));
+      oaiResponse.getValue().getError().add(errorType);
+      return oaiResponse;
+    }
+    var searchResult = performSearch(request);
 
     var records = recordTransformer.transform(searchResult.hits);
     var listRecords =
@@ -73,11 +88,12 @@ public class ListRecords {
   private JAXBElement<OAIPMHtype> createBaseResponse(
       OaiPmhRequest context, ObjectFactory objectFactory) {
     var oaiResponse = baseResponse(objectFactory);
+    var metadataPrefix = context.getMetadataPrefix();
     populateListRecordsRequest(
         context.getFrom(),
         context.getUntil(),
         context.getResumptionToken(),
-        context.getMetadataPrefix(),
+        metadataPrefix,
         oaiResponse.getValue());
     return oaiResponse;
   }

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ListRecords.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ListRecords.java
@@ -61,11 +61,7 @@ public class ListRecords {
               ? MetadataPrefix.fromPrefix(request.getMetadataPrefix())
               : MetadataPrefix.OAI_DC;
     } catch (MetadataPrefixNotSupportedException e) {
-      var errorType = objectFactory.createOAIPMHerrorType();
-      errorType.setCode(OAIPMHerrorcodeType.CANNOT_DISSEMINATE_FORMAT);
-      errorType.setValue(HtmlEscapers.htmlEscaper().escape(request.getMetadataPrefix()));
-      oaiResponse.getValue().getError().add(errorType);
-      return oaiResponse;
+      return reportCannotDisseminateFormatError(request, objectFactory, oaiResponse);
     }
     var searchResult = performSearch(request);
 
@@ -74,6 +70,15 @@ public class ListRecords {
         createListRecordsResponse(records, searchResult.totalSize(), request, objectFactory);
 
     oaiResponse.getValue().setListRecords(listRecords);
+    return oaiResponse;
+  }
+
+  private static JAXBElement<OAIPMHtype> reportCannotDisseminateFormatError(
+      OaiPmhRequest request, ObjectFactory objectFactory, JAXBElement<OAIPMHtype> oaiResponse) {
+    var errorType = objectFactory.createOAIPMHerrorType();
+    errorType.setCode(OAIPMHerrorcodeType.CANNOT_DISSEMINATE_FORMAT);
+    errorType.setValue(HtmlEscapers.htmlEscaper().escape(request.getMetadataPrefix()));
+    oaiResponse.getValue().getError().add(errorType);
     return oaiResponse;
   }
 

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/MetadataPrefix.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/MetadataPrefix.java
@@ -1,0 +1,32 @@
+package no.sikt.nva.oai.pmh.handler.oaipmh;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public enum MetadataPrefix {
+  OAI_DC("oai_dc");
+
+  private static final Map<String, MetadataPrefix> prefixMap = new HashMap<>();
+
+  static {
+    for (MetadataPrefix metadataPrefix : values()) {
+      prefixMap.put(metadataPrefix.getPrefix(), metadataPrefix);
+    }
+  }
+
+  private final String prefix;
+
+  MetadataPrefix(String prefix) {
+    this.prefix = prefix;
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public static MetadataPrefix fromPrefix(String prefix) {
+    return Optional.ofNullable(prefixMap.get(prefix))
+        .orElseThrow(() -> new MetadataPrefixNotSupportedException(prefix));
+  }
+}

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/MetadataPrefixNotSupportedException.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/MetadataPrefixNotSupportedException.java
@@ -1,0 +1,12 @@
+package no.sikt.nva.oai.pmh.handler.oaipmh;
+
+import com.google.common.html.HtmlEscapers;
+
+public class MetadataPrefixNotSupportedException extends RuntimeException {
+  public MetadataPrefixNotSupportedException(String metadataPrefix) {
+    super(
+        "Metadata prefix '"
+            + HtmlEscapers.htmlEscaper().escape(metadataPrefix)
+            + "' is not supported");
+  }
+}


### PR DESCRIPTION
Report proper error on not supported metadataPrefix.
Defaults to "oai_dc".