### PR TITLE
Np 49471 datestamp format

### DIFF
--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ListRecordsRequestHandler.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ListRecordsRequestHandler.java
@@ -207,8 +207,8 @@ public class ListRecordsRequestHandler implements OaiPmhRequestHandler<ListRecor
         nonNull(request.getResumptionToken()) ? request.getResumptionToken().getValue() : null;
     oaiPmhType.getRequest().setVerb(VerbType.LIST_RECORDS);
     oaiPmhType.getRequest().setResumptionToken(resumptionTokenValue);
-    oaiPmhType.getRequest().setFrom(request.getFrom().getValue().orElse(null));
-    oaiPmhType.getRequest().setUntil(request.getUntil().getValue().orElse(null));
+    oaiPmhType.getRequest().setFrom(request.getFrom().getOriginalSource().orElse(null));
+    oaiPmhType.getRequest().setUntil(request.getUntil().getOriginalSource().orElse(null));
     oaiPmhType.getRequest().setSet(request.getSetSpec().getValue().orElse(null));
     oaiPmhType.getRequest().setMetadataPrefix(request.getMetadataPrefix().getPrefix());
   }

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/NullableWrapper.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/NullableWrapper.java
@@ -12,7 +12,5 @@ public interface NullableWrapper<T> {
     return getValue().orElse(other);
   }
 
-  boolean isPresent();
-
   Optional<T> getValue();
 }

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/OaiPmhDateTime.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/OaiPmhDateTime.java
@@ -12,11 +12,13 @@ import java.util.Optional;
 import nva.commons.core.StringUtils;
 
 public final class OaiPmhDateTime implements NullableWrapper<String> {
-  public static final OaiPmhDateTime EMPTY_INSTANCE = new OaiPmhDateTime(null);
+  public static final OaiPmhDateTime EMPTY_INSTANCE = new OaiPmhDateTime(null, null);
   private final Instant instant;
+  private final String originalSource;
 
-  private OaiPmhDateTime(Instant instant) {
+  private OaiPmhDateTime(Instant instant, String originalSource) {
     this.instant = instant;
+    this.originalSource = originalSource;
   }
 
   public static OaiPmhDateTime from(String value) {
@@ -30,7 +32,7 @@ public final class OaiPmhDateTime implements NullableWrapper<String> {
     } catch (DateTimeParseException e) {
       instant = getInstantFromDate(value);
     }
-    return new OaiPmhDateTime(instant);
+    return new OaiPmhDateTime(instant, value);
   }
 
   @Override
@@ -43,6 +45,10 @@ public final class OaiPmhDateTime implements NullableWrapper<String> {
     return Optional.ofNullable(instant)
         .map(localInstant -> ZonedDateTime.ofInstant(localInstant, ZoneId.of("Z")))
         .map(DateTimeFormatter.ISO_DATE_TIME::format);
+  }
+
+  public Optional<String> getOriginalSource() {
+    return Optional.ofNullable(originalSource);
   }
 
   private static Instant getInstantFromDate(String value) {

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/OaiPmhDateTime.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/OaiPmhDateTime.java
@@ -28,8 +28,7 @@ public final class OaiPmhDateTime implements NullableWrapper<String> {
     try {
       instant = Instant.parse(value);
       if (instant.getNano() != 0) {
-        throw new BadArgumentException(
-            "datestamp fields with time only supports second granularity");
+        throw new BadArgumentException("datestamp fields with time does not support nanoseconds.");
       }
     } catch (DateTimeParseException e) {
       instant = getInstantFromDate(value);

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/OaiPmhDateTime.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/OaiPmhDateTime.java
@@ -1,7 +1,5 @@
 package no.sikt.nva.oai.pmh.handler.oaipmh;
 
-import static java.util.Objects.nonNull;
-
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -29,15 +27,14 @@ public final class OaiPmhDateTime implements NullableWrapper<String> {
     Instant instant;
     try {
       instant = Instant.parse(value);
+      if (instant.getNano() != 0) {
+        throw new BadArgumentException(
+            "datestamp fields with time only supports second granularity");
+      }
     } catch (DateTimeParseException e) {
       instant = getInstantFromDate(value);
     }
     return new OaiPmhDateTime(instant, value);
-  }
-
-  @Override
-  public boolean isPresent() {
-    return nonNull(instant);
   }
 
   @Override

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ResumptionToken.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ResumptionToken.java
@@ -30,14 +30,22 @@ public record ResumptionToken(
     originalRequest
         .getFrom()
         .ifPresent(
-            value ->
-                unencodedValueBuilder.append(AMPERSAND).append(FROM).append(EQUALS).append(value));
+            ignored ->
+                unencodedValueBuilder
+                    .append(AMPERSAND)
+                    .append(FROM)
+                    .append(EQUALS)
+                    .append(originalRequest.getFrom().getOriginalSource().orElseThrow()));
 
     originalRequest
         .getUntil()
         .ifPresent(
-            value ->
-                unencodedValueBuilder.append(AMPERSAND).append(UNTIL).append(EQUALS).append(value));
+            ignored ->
+                unencodedValueBuilder
+                    .append(AMPERSAND)
+                    .append(UNTIL)
+                    .append(EQUALS)
+                    .append(originalRequest.getUntil().getOriginalSource().orElseThrow()));
 
     originalRequest
         .getSetSpec()

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ResumptionToken.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/ResumptionToken.java
@@ -9,8 +9,7 @@ import java.util.stream.Collectors;
 import no.sikt.nva.oai.pmh.handler.oaipmh.request.ListRecordsRequest;
 import nva.commons.core.StringUtils;
 
-public record ResumptionToken(
-    ListRecordsRequest originalRequest, OaiPmhDateTime cursor, int totalSize) {
+public record ResumptionToken(ListRecordsRequest originalRequest, String cursor, int totalSize) {
   private static final String EQUALS = "=";
   private static final String FROM = "from";
   private static final String UNTIL = "until";
@@ -53,10 +52,15 @@ public record ResumptionToken(
             value ->
                 unencodedValueBuilder.append(AMPERSAND).append(SET).append(EQUALS).append(value));
 
-    cursor.ifPresent(
-        value ->
-            unencodedValueBuilder.append(AMPERSAND).append(CURSOR).append(EQUALS).append(value));
-    unencodedValueBuilder.append(AMPERSAND).append(TOTAL_SIZE).append(EQUALS).append(totalSize);
+    unencodedValueBuilder
+        .append(AMPERSAND)
+        .append(CURSOR)
+        .append(EQUALS)
+        .append(cursor)
+        .append(AMPERSAND)
+        .append(TOTAL_SIZE)
+        .append(EQUALS)
+        .append(totalSize);
     return URLEncoder.encode(unencodedValueBuilder.toString(), StandardCharsets.UTF_8);
   }
 
@@ -86,8 +90,6 @@ public record ResumptionToken(
             OaiPmhDateTime.from(until),
             SetSpec.from(set),
             MetadataPrefix.fromPrefix(metadataPrefix));
-    return Optional.of(
-        new ResumptionToken(
-            originalRequest, OaiPmhDateTime.from(cursor), Integer.parseInt(totalSize)));
+    return Optional.of(new ResumptionToken(originalRequest, cursor, Integer.parseInt(totalSize)));
   }
 }

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/SetSpec.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/SetSpec.java
@@ -1,7 +1,5 @@
 package no.sikt.nva.oai.pmh.handler.oaipmh;
 
-import static java.util.Objects.nonNull;
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -26,11 +24,6 @@ public record SetSpec(SetRoot root, String... children) implements NullableWrapp
       return new SetSpec(
           SetRoot.fromValue(parts[ZERO]), Arrays.copyOfRange(parts, ONE, parts.length));
     }
-  }
-
-  @Override
-  public boolean isPresent() {
-    return nonNull(root);
   }
 
   @Override

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/SimplifiedRecordTransformer.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/SimplifiedRecordTransformer.java
@@ -5,6 +5,9 @@ import static java.util.Objects.nonNull;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import no.sikt.nva.oai.pmh.handler.oaipmh.SetSpec.SetRoot;
@@ -148,10 +151,17 @@ public class SimplifiedRecordTransformer implements RecordTransformer {
   private static HeaderType populateHeaderType(ResourceSearchResponse response) {
     var headerType = new ObjectFactory().createHeaderType();
     headerType.setIdentifier(response.id().toString());
-    headerType.setDatestamp(response.recordMetadata().modifiedDate());
+    var datestamp = toDatestamp(response.recordMetadata().modifiedDate());
+    headerType.setDatestamp(datestamp);
     headerType
         .getSetSpec()
         .add(new SetSpec(SetRoot.RESOURCE_TYPE_GENERAL, response.type()).getValue().orElseThrow());
     return headerType;
+  }
+
+  private static String toDatestamp(String input) {
+    var instant = Instant.parse(input);
+    var truncated = instant.atOffset(ZoneOffset.UTC).withNano(0);
+    return truncated.format(DateTimeFormatter.ISO_INSTANT);
   }
 }

--- a/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/HitBuilder.java
+++ b/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/HitBuilder.java
@@ -6,8 +6,6 @@ import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 
 public class HitBuilder {
@@ -84,8 +82,7 @@ public class HitBuilder {
         "entityDescription",
         entityDescriptionNode(
             title, referenceNode, publicationDateNodeToUse, contributorsPreviewNode));
-    rootNode.put(
-        "modifiedDate", ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+    rootNode.put("modifiedDate", "2023-01-01T01:02:03.123456789Z");
     return rootNode;
   }
 

--- a/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandlerTest.java
+++ b/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandlerTest.java
@@ -464,6 +464,20 @@ public class OaiPmhHandlerTest {
   }
 
   @ParameterizedTest
+  @MethodSource("datestampIssueListRecordsParameterProvider")
+  void shouldReportErrorOnInitialListRecordsWithNanoSecondDataStamp(
+      String method, String from, String until) throws Exception {
+
+    var response =
+        performListRecordsOperation(
+            method, from, until, MetadataPrefix.OAI_DC.getPrefix(), null, null);
+    assertXmlResponseWithError(
+        response,
+        OAIPMHerrorcodeType.BAD_ARGUMENT,
+        "datestamp fields with time does not support nanoseconds.");
+  }
+
+  @ParameterizedTest
   @ValueSource(strings = {GET_METHOD, POST_METHOD})
   void shouldListRecordsOnInitialQueryWithOnlyRequiredParameters(String method) throws Exception {
     var expectedIdentifiers =
@@ -1370,5 +1384,33 @@ public class OaiPmhHandlerTest {
         Arguments.of(VerbType.LIST_IDENTIFIERS, GET_METHOD),
         Arguments.of(VerbType.GET_RECORD, POST_METHOD),
         Arguments.of(VerbType.LIST_IDENTIFIERS, POST_METHOD));
+  }
+
+  private static Stream<Arguments> datestampIssueListRecordsParameterProvider() {
+    var secondsGranularityDate = "2020-01-01T00:00:00Z";
+    var nanosGranularityDate = "2020-01-01T00:00:00.123456789Z";
+    var nameTemplate =
+        "%s request with nano resolution in %s parameter should report bad argument error.";
+    return Stream.of(
+        Arguments.argumentSet(
+            nameTemplate.formatted(GET_METHOD, "until"),
+            GET_METHOD,
+            secondsGranularityDate,
+            nanosGranularityDate),
+        Arguments.argumentSet(
+            nameTemplate.formatted(GET_METHOD, "from"),
+            GET_METHOD,
+            nanosGranularityDate,
+            secondsGranularityDate),
+        Arguments.argumentSet(
+            nameTemplate.formatted(GET_METHOD, "until"),
+            POST_METHOD,
+            secondsGranularityDate,
+            nanosGranularityDate),
+        Arguments.argumentSet(
+            nameTemplate.formatted(GET_METHOD, "from"),
+            POST_METHOD,
+            nanosGranularityDate,
+            secondsGranularityDate));
   }
 }

--- a/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandlerTest.java
+++ b/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandlerTest.java
@@ -6,17 +6,19 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.Objects.nonNull;
+import static no.sikt.nva.oai.pmh.handler.oaipmh.request.OaiPmhParameterName.FROM;
+import static no.sikt.nva.oai.pmh.handler.oaipmh.request.OaiPmhParameterName.SET;
+import static no.sikt.nva.oai.pmh.handler.oaipmh.request.OaiPmhParameterName.UNTIL;
+import static no.sikt.nva.oai.pmh.handler.oaipmh.request.OaiPmhParameterName.VERB;
 import static no.unit.nva.constants.Words.RESOURCES;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyIterable.*;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableWithSize.iterableWithSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsNot.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -40,6 +42,7 @@ import java.net.HttpURLConnection;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -56,6 +59,7 @@ import no.sikt.nva.oai.pmh.handler.oaipmh.ResumptionToken;
 import no.sikt.nva.oai.pmh.handler.oaipmh.SetSpec;
 import no.sikt.nva.oai.pmh.handler.oaipmh.SetSpec.SetRoot;
 import no.sikt.nva.oai.pmh.handler.oaipmh.request.ListRecordsRequest;
+import no.sikt.nva.oai.pmh.handler.oaipmh.request.OaiPmhParameterName;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.constants.Words;
 import no.unit.nva.search.common.records.SwsResponse;
@@ -205,7 +209,10 @@ public class OaiPmhHandlerTest {
     var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
     var xpathEngine = getXpathEngine();
 
-    assertResponseRequestContains(VerbType.LIST_SETS, response, xpathEngine);
+    var expectedRequestParameters =
+        new EnumMap<OaiPmhParameterName, String>(OaiPmhParameterName.class);
+    expectedRequestParameters.put(VERB, VerbType.LIST_SETS.value());
+    assertResponseRequestContains(expectedRequestParameters, response, xpathEngine);
 
     var listSetSpecNodes =
         xpathEngine.selectNodes("/oai:OAI-PMH/oai:ListSets/oai:set/oai:setSpec", response);
@@ -257,7 +264,10 @@ public class OaiPmhHandlerTest {
     var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
     var xpathEngine = getXpathEngine();
 
-    assertResponseRequestContains(VerbType.IDENTIFY, response, xpathEngine);
+    var expectedRequestParameters =
+        new EnumMap<OaiPmhParameterName, String>(OaiPmhParameterName.class);
+    expectedRequestParameters.put(VERB, VerbType.IDENTIFY.value());
+    assertResponseRequestContains(expectedRequestParameters, response, xpathEngine);
 
     var repositoryName = getIdentifyChildNodeText(xpathEngine, response, "repositoryName");
     assertThat(repositoryName, is(equalTo("NVA-OAI-PMH")));
@@ -271,7 +281,10 @@ public class OaiPmhHandlerTest {
     var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
     var xpathEngine = getXpathEngine();
 
-    assertResponseRequestContains(VerbType.IDENTIFY, response, xpathEngine);
+    var expectedRequestParameters =
+        new EnumMap<OaiPmhParameterName, String>(OaiPmhParameterName.class);
+    expectedRequestParameters.put(VERB, VerbType.IDENTIFY.value());
+    assertResponseRequestContains(expectedRequestParameters, response, xpathEngine);
 
     var baseURL = getIdentifyChildNodeText(xpathEngine, response, "baseURL");
 
@@ -286,7 +299,10 @@ public class OaiPmhHandlerTest {
     var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
     var xpathEngine = getXpathEngine();
 
-    assertResponseRequestContains(VerbType.IDENTIFY, response, xpathEngine);
+    var expectedRequestParameters =
+        new EnumMap<OaiPmhParameterName, String>(OaiPmhParameterName.class);
+    expectedRequestParameters.put(VERB, VerbType.IDENTIFY.value());
+    assertResponseRequestContains(expectedRequestParameters, response, xpathEngine);
 
     var protocolVersion =
         getIdentifyChildNodeText(xpathEngine, response, PROTOCOL_VERSION_NODE_NAME);
@@ -302,7 +318,10 @@ public class OaiPmhHandlerTest {
     var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
     var xpathEngine = getXpathEngine();
 
-    assertResponseRequestContains(VerbType.IDENTIFY, response, xpathEngine);
+    var expectedRequestParameters =
+        new EnumMap<OaiPmhParameterName, String>(OaiPmhParameterName.class);
+    expectedRequestParameters.put(VERB, VerbType.IDENTIFY.value());
+    assertResponseRequestContains(expectedRequestParameters, response, xpathEngine);
 
     var earliestDatestamp =
         getIdentifyChildNodeText(xpathEngine, response, EARLIEST_DATESTAMP_NODE_NAME);
@@ -318,7 +337,10 @@ public class OaiPmhHandlerTest {
     var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
     var xpathEngine = getXpathEngine();
 
-    assertResponseRequestContains(VerbType.IDENTIFY, response, xpathEngine);
+    var expectedRequestParameters =
+        new EnumMap<OaiPmhParameterName, String>(OaiPmhParameterName.class);
+    expectedRequestParameters.put(VERB, VerbType.IDENTIFY.value());
+    assertResponseRequestContains(expectedRequestParameters, response, xpathEngine);
 
     var deletedRecord = getIdentifyChildNodeText(xpathEngine, response, DELETED_RECORD_NODE_NAME);
 
@@ -333,7 +355,10 @@ public class OaiPmhHandlerTest {
     var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
     var xpathEngine = getXpathEngine();
 
-    assertResponseRequestContains(VerbType.IDENTIFY, response, xpathEngine);
+    var expectedRequestParameters =
+        new EnumMap<OaiPmhParameterName, String>(OaiPmhParameterName.class);
+    expectedRequestParameters.put(VERB, VerbType.IDENTIFY.value());
+    assertResponseRequestContains(expectedRequestParameters, response, xpathEngine);
 
     var granularity = getIdentifyChildNodeText(xpathEngine, response, GRANULARITY_NODE_NAME);
 
@@ -348,7 +373,10 @@ public class OaiPmhHandlerTest {
     var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
     var xpathEngine = getXpathEngine();
 
-    assertResponseRequestContains(VerbType.IDENTIFY, response, xpathEngine);
+    var expectedRequestParameters =
+        new EnumMap<OaiPmhParameterName, String>(OaiPmhParameterName.class);
+    expectedRequestParameters.put(VERB, VerbType.IDENTIFY.value());
+    assertResponseRequestContains(expectedRequestParameters, response, xpathEngine);
 
     var adminEmailNodes =
         xpathEngine.selectNodes("/oai:OAI-PMH/oai:Identify/oai:adminEmail", response);
@@ -366,7 +394,10 @@ public class OaiPmhHandlerTest {
     var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
     var xpathEngine = getXpathEngine();
 
-    assertResponseRequestContains(VerbType.LIST_METADATA_FORMATS, response, xpathEngine);
+    var expectedRequestParameters =
+        new EnumMap<OaiPmhParameterName, String>(OaiPmhParameterName.class);
+    expectedRequestParameters.put(VERB, VerbType.LIST_METADATA_FORMATS.value());
+    assertResponseRequestContains(expectedRequestParameters, response, xpathEngine);
 
     var metadataFormatNodes =
         xpathEngine.selectNodes(
@@ -571,7 +602,7 @@ public class OaiPmhHandlerTest {
   }
 
   @Test
-  void shouldPopulateRecordHeaderDatestamp() throws IOException, JAXBException {
+  void shouldUseCorrectDateFormatOnHeaderDatestamp() throws IOException, JAXBException {
     var inputStream = defaultHitAndRequest();
 
     var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
@@ -583,7 +614,7 @@ public class OaiPmhHandlerTest {
             "/oai:OAI-PMH/oai:ListRecords/oai:record/oai:header/oai:datestamp",
             response);
 
-    assertThat(datestamp, is(not(nullValue())));
+    assertThat(datestamp, is(equalTo("2023-01-01T01:02:03Z")));
   }
 
   @Test
@@ -791,7 +822,19 @@ public class OaiPmhHandlerTest {
         performListRecordsOperation(method, from, until, metadataPrefix, setSpec, resumptionToken);
     var xpathEngine = getXpathEngine();
 
-    assertResponseRequestContains(VerbType.LIST_RECORDS, response, xpathEngine);
+    var expectedRequestParameters =
+        new EnumMap<OaiPmhParameterName, String>(OaiPmhParameterName.class);
+    expectedRequestParameters.put(VERB, VerbType.LIST_RECORDS.value());
+    if (nonNull(from)) {
+      expectedRequestParameters.put(FROM, from);
+    }
+    if (nonNull(until)) {
+      expectedRequestParameters.put(UNTIL, until);
+    }
+    if (nonNull(setRoot) && nonNull(setChild)) {
+      expectedRequestParameters.put(SET, setRoot + ":" + setChild);
+    }
+    assertResponseRequestContains(expectedRequestParameters, response, xpathEngine);
 
     var recordNodes = xpathEngine.selectNodes("/oai:OAI-PMH/oai:ListRecords/oai:record", response);
     assertThat(recordNodes, iterableWithSize(expectedRecordCount));
@@ -1247,18 +1290,20 @@ public class OaiPmhHandlerTest {
   }
 
   private void assertResponseRequestContains(
-      VerbType verbType, Source source, JAXPXPathEngine xpathEngine) {
+      EnumMap<OaiPmhParameterName, String> parameters, Source source, JAXPXPathEngine xpathEngine) {
     var requestNodes = xpathEngine.selectNodes("/oai:OAI-PMH/oai:request", source);
     assertThat(requestNodes, iterableWithSize(1));
 
-    var verb =
-        requestNodes
-            .iterator()
-            .next()
-            .getAttributes()
-            .getNamedItem(VERB_ATTRIBUTE_NAME)
-            .getNodeValue();
-    assertThat(verb, is(equalTo(verbType.value())));
+    var attributes = requestNodes.iterator().next().getAttributes();
+
+    parameters
+        .entrySet()
+        .forEach(
+            entry -> {
+              assertThat(
+                  entry.getValue(),
+                  is(equalTo(attributes.getNamedItem(entry.getKey().getName()).getNodeValue())));
+            });
   }
 
   private static JAXPXPathEngine getXpathEngine() {

--- a/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandlerTest.java
+++ b/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandlerTest.java
@@ -528,8 +528,7 @@ public class OaiPmhHandlerTest {
             OaiPmhDateTime.from(untilDate),
             SetSpec.EMPTY_INSTANCE,
             metadataPrefix);
-    var resumptionToken =
-        new ResumptionToken(listRecordsRequest, OaiPmhDateTime.from(cursor), 8).getValue();
+    var resumptionToken = new ResumptionToken(listRecordsRequest, cursor, 8).getValue();
 
     var expectedIdentifiers =
         List.of(
@@ -564,8 +563,7 @@ public class OaiPmhHandlerTest {
             SetSpec.EMPTY_INSTANCE,
             metadataPrefix);
 
-    var resumptionToken =
-        new ResumptionToken(listRecordsRequest, OaiPmhDateTime.from(cursor), 8).getValue();
+    var resumptionToken = new ResumptionToken(listRecordsRequest, cursor, 8).getValue();
 
     var expectedIdentifiers =
         List.of(
@@ -858,7 +856,7 @@ public class OaiPmhHandlerTest {
           nonNull(cursor) ? "2016-01-06T08:55:42.820948673Z" : "2016-01-03T08:55:42.820948673Z";
       assertThat(
           "Expects cursor in token to be 1 ms ahead of the last record in page",
-          token.cursor().getValue().orElseThrow(),
+          token.cursor(),
           is(equalTo(expectedCursorInToken)));
     } else {
       assertNoResumptionToken(xpathEngine, response);


### PR DESCRIPTION
- from and until parameters in ListRecords can no longer have more than seconds resolution as stated in the spec
- from and until parameters keep their original value in the resumption token
- datestamp in record headers only uses seconds resolution