### PR TITLE
fixed content type header in responses

### DIFF
--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandler.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandler.java
@@ -91,7 +91,7 @@ public class OaiPmhHandler extends ApiGatewayHandler<String, String> {
 
   @Override
   protected List<MediaType> listSupportedMediaTypes() {
-    return List.of(MediaType.APPLICATION_XML_UTF_8);
+    return List.of(MediaType.XML_UTF_8);
   }
 
   @Override


### PR DESCRIPTION
Now uses `text/xml; charset=utf-8` according to spec.