### PR TITLE
support for GetRecord

### DIFF
--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/IdDoesNotExistException.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/IdDoesNotExistException.java
@@ -1,0 +1,9 @@
+package no.sikt.nva.oai.pmh.handler.oaipmh;
+
+import org.openarchives.oai.pmh.v2.OAIPMHerrorcodeType;
+
+public class IdDoesNotExistException extends OaiPmhException {
+  public IdDoesNotExistException() {
+    super(OAIPMHerrorcodeType.ID_DOES_NOT_EXIST, "identifier does not exist");
+  }
+}

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/RecordTransformer.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/RecordTransformer.java
@@ -5,5 +5,7 @@ import no.unit.nva.search.resource.response.ResourceSearchResponse;
 import org.openarchives.oai.pmh.v2.RecordType;
 
 public interface RecordTransformer {
+  RecordType transform(ResourceSearchResponse resourceSearchResponse);
+
   List<RecordType> transform(List<ResourceSearchResponse> hits);
 }

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/handlers/GetRecordRequestHandler.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/handlers/GetRecordRequestHandler.java
@@ -1,0 +1,62 @@
+package no.sikt.nva.oai.pmh.handler.oaipmh.handlers;
+
+import static no.sikt.nva.oai.pmh.handler.oaipmh.OaiPmhUtils.baseResponse;
+
+import jakarta.xml.bind.JAXBElement;
+import no.sikt.nva.oai.pmh.handler.oaipmh.IdDoesNotExistException;
+import no.sikt.nva.oai.pmh.handler.oaipmh.RecordTransformer;
+import no.sikt.nva.oai.pmh.handler.oaipmh.request.GetRecordRequest;
+import no.sikt.nva.oai.pmh.handler.repository.ResourceRepository;
+import org.openarchives.oai.pmh.v2.GetRecordType;
+import org.openarchives.oai.pmh.v2.OAIPMHtype;
+import org.openarchives.oai.pmh.v2.ObjectFactory;
+import org.openarchives.oai.pmh.v2.RecordType;
+import org.openarchives.oai.pmh.v2.VerbType;
+
+public class GetRecordRequestHandler implements OaiPmhRequestHandler<GetRecordRequest> {
+  private final ResourceRepository resourceRepository;
+  private final RecordTransformer recordTransformer;
+
+  public GetRecordRequestHandler(
+      ResourceRepository resourceRepository, RecordTransformer recordTransformer) {
+    this.resourceRepository = resourceRepository;
+    this.recordTransformer = recordTransformer;
+  }
+
+  @Override
+  public JAXBElement<OAIPMHtype> handleRequest(GetRecordRequest request) {
+    var objectFactory = new ObjectFactory();
+
+    var oaiResponse = createBaseResponse(request, objectFactory);
+
+    var resource =
+        resourceRepository
+            .fetchByIdentifier(request.getIdentifier())
+            .orElseThrow(IdDoesNotExistException::new);
+
+    var record = recordTransformer.transform(resource);
+    var getRecord = createGetRecordResponse(record, objectFactory);
+
+    oaiResponse.getValue().setGetRecord(getRecord);
+    return oaiResponse;
+  }
+
+  private GetRecordType createGetRecordResponse(RecordType record, ObjectFactory objectFactory) {
+    var getRecord = objectFactory.createGetRecordType();
+    getRecord.setRecord(record);
+    return getRecord;
+  }
+
+  private JAXBElement<OAIPMHtype> createBaseResponse(
+      GetRecordRequest request, ObjectFactory objectFactory) {
+    var oaiResponse = baseResponse(objectFactory);
+    populateGetRecordRequest(request, oaiResponse.getValue());
+    return oaiResponse;
+  }
+
+  private static void populateGetRecordRequest(GetRecordRequest request, OAIPMHtype oaiPmhType) {
+    oaiPmhType.getRequest().setVerb(VerbType.GET_RECORD);
+    oaiPmhType.getRequest().setMetadataPrefix(request.getMetadataPrefix().getPrefix());
+    oaiPmhType.getRequest().setIdentifier(request.getIdentifier());
+  }
+}

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/handlers/OaiPmhRequestHandlerRegistry.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/handlers/OaiPmhRequestHandlerRegistry.java
@@ -28,6 +28,9 @@ public class OaiPmhRequestHandlerRegistry {
     handlerSuppliers.put(
         VerbType.LIST_RECORDS,
         () -> new ListRecordsRequestHandler(resourceRepository, recordTransformer, batchSize));
+    handlerSuppliers.put(
+        VerbType.GET_RECORD,
+        () -> new GetRecordRequestHandler(resourceRepository, recordTransformer));
   }
 
   @SuppressWarnings("unchecked")

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/request/GetRecordRequest.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/request/GetRecordRequest.java
@@ -1,0 +1,28 @@
+package no.sikt.nva.oai.pmh.handler.oaipmh.request;
+
+import no.sikt.nva.oai.pmh.handler.oaipmh.MetadataPrefix;
+import org.openarchives.oai.pmh.v2.VerbType;
+
+public class GetRecordRequest extends OaiPmhRequest {
+  private final String identifier;
+  private final MetadataPrefix metadataPrefix;
+
+  public GetRecordRequest(String identifier, MetadataPrefix metadataPrefix) {
+    super();
+    this.identifier = identifier;
+    this.metadataPrefix = metadataPrefix;
+  }
+
+  public String getIdentifier() {
+    return identifier;
+  }
+
+  public MetadataPrefix getMetadataPrefix() {
+    return metadataPrefix;
+  }
+
+  @Override
+  public VerbType getVerbType() {
+    return VerbType.GET_RECORD;
+  }
+}

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/request/GetRecordsRequestFactory.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/request/GetRecordsRequestFactory.java
@@ -1,0 +1,20 @@
+package no.sikt.nva.oai.pmh.handler.oaipmh.request;
+
+import static no.sikt.nva.oai.pmh.handler.oaipmh.request.OaiPmhParameterName.IDENTIFIER;
+import static no.sikt.nva.oai.pmh.handler.oaipmh.request.OaiPmhParameterName.METADATA_PREFIX;
+
+import no.sikt.nva.oai.pmh.handler.oaipmh.BadArgumentException;
+import no.sikt.nva.oai.pmh.handler.oaipmh.MetadataPrefix;
+import nva.commons.apigateway.RequestInfo;
+
+public class GetRecordsRequestFactory implements OaiPmhRequestFactory {
+
+  @Override
+  public OaiPmhRequest create(RequestInfo requestInfo, String body) {
+    var identifier = RequestUtils.extractParameter(IDENTIFIER, requestInfo, body).orElse(null);
+    var metadataPrefix =
+        RequestUtils.extractParameter(METADATA_PREFIX, requestInfo, body)
+            .orElseThrow(() -> new BadArgumentException("metadataPrefix is required"));
+    return new GetRecordRequest(identifier, MetadataPrefix.fromPrefix(metadataPrefix));
+  }
+}

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/request/OaiPmhRequestFactoryRegistry.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/request/OaiPmhRequestFactoryRegistry.java
@@ -16,7 +16,8 @@ public final class OaiPmhRequestFactoryRegistry {
           VerbType.IDENTIFY.value(), new IdentifyRequestFactory(),
           VerbType.LIST_METADATA_FORMATS.value(), new ListMetadataFormatsRequestFactory(),
           VerbType.LIST_SETS.value(), new ListSetsRequestFactory(),
-          VerbType.LIST_RECORDS.value(), new ListRecordsRequestFactory());
+          VerbType.LIST_RECORDS.value(), new ListRecordsRequestFactory(),
+          VerbType.GET_RECORD.value(), new GetRecordsRequestFactory());
 
   private OaiPmhRequestFactoryRegistry() {}
 

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/transformers/SimplifiedRecordTransformer.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/transformers/SimplifiedRecordTransformer.java
@@ -26,6 +26,11 @@ public class SimplifiedRecordTransformer implements RecordTransformer {
   private static final char DASH = '-';
 
   @Override
+  public RecordType transform(ResourceSearchResponse resourceSearchResponse) {
+    return toRecord(resourceSearchResponse);
+  }
+
+  @Override
   public List<RecordType> transform(List<ResourceSearchResponse> hits) {
     if (isNull(hits) || hits.isEmpty()) {
       return Collections.emptyList();

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/repository/ResourceClientResourceRepository.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/repository/ResourceClientResourceRepository.java
@@ -73,6 +73,26 @@ public class ResourceClientResourceRepository implements ResourceRepository {
     }
   }
 
+  @Override
+  public Optional<ResourceSearchResponse> fetchByIdentifier(String identifier) {
+    var query = buildFetchResourceByIdentifierQuery(identifier);
+    var pagedResponse = doQuery(query);
+    return pagedResponse.hits().isEmpty()
+        ? Optional.empty()
+        : Optional.of(pagedResponse.hits().getFirst());
+  }
+
+  private ResourceSearchQuery buildFetchResourceByIdentifierQuery(String identifier) {
+    var builder = buildQueryWithMandatoryParameters(1);
+    applyIdentifierParameter(builder, identifier);
+    return applyFilterAndBuild(builder);
+  }
+
+  private void applyIdentifierParameter(
+      ParameterValidator<ResourceParameter, ResourceSearchQuery> builder, String identifier) {
+    builder.withParameter(ResourceParameter.ID, identifier);
+  }
+
   private ResourceSearchQuery buildAggregationsQuery() {
     try {
       return ResourceSearchQuery.builder()

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/repository/ResourceRepository.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/repository/ResourceRepository.java
@@ -1,8 +1,10 @@
 package no.sikt.nva.oai.pmh.handler.repository;
 
+import java.util.Optional;
 import java.util.Set;
 import no.sikt.nva.oai.pmh.handler.oaipmh.OaiPmhDateTime;
 import no.sikt.nva.oai.pmh.handler.oaipmh.SetSpec;
+import no.unit.nva.search.resource.response.ResourceSearchResponse;
 
 public interface ResourceRepository {
   PagedResponse fetchInitialPage(
@@ -11,4 +13,6 @@ public interface ResourceRepository {
   PagedResponse fetchNextPage(String from, OaiPmhDateTime until, SetSpec setSpec, int pageSize);
 
   Set<String> fetchAvailableInstanceTypes();
+
+  Optional<ResourceSearchResponse> fetchByIdentifier(String identifier);
 }


### PR DESCRIPTION
Support for GetRecord with our URI identifier. Uses same metadata transformer and provider as ListRecords, so I have not duplicated tests for content of record in GetRecord.

Later I will add support for GetRecord using alternative identifiers like DOI, handle, Cristin, ISSN, ISBN etc