### PR TITLE
Np 49527 doi handling oai

### DIFF
--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/transformers/SimplifiedRecordTransformer.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/transformers/SimplifiedRecordTransformer.java
@@ -92,9 +92,6 @@ public class SimplifiedRecordTransformer implements RecordTransformer {
     if (nonNull(response.publishingDetails().doi())) {
       appendToOaiDc(oaiDcType, response.publishingDetails().doi().toString(), null);
     }
-    if (nonNull(response.doi())) {
-      appendToOaiDc(oaiDcType, response.doi().toString(), null);
-    }
   }
 
   private static void appendAll(OaiDcType oaiDcType, Set<String> identifiers, String prefix) {

--- a/search-commons/src/main/java/no/unit/nva/search/resource/SimplifiedMutator.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/SimplifiedMutator.java
@@ -55,6 +55,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -139,7 +140,6 @@ public class SimplifiedMutator implements JsonNodeMutator {
     return responseBuilder()
         .withId(NodeUtils.toUri(source.path(ID)))
         .withIdentifier(source.path(IDENTIFIER))
-        .withDoi(NodeUtils.toUri(source.path(DOI)))
         .withMainTitle(source.path(ENTITY_DESCRIPTION).path(MAIN_TITLE))
         .withMainLanguageAbstract(source.path(ENTITY_DESCRIPTION).path(ABSTRACT))
         .withDescription(source.path(ENTITY_DESCRIPTION).path(Constants.DESCRIPTION))
@@ -248,13 +248,21 @@ public class SimplifiedMutator implements JsonNodeMutator {
     var publicationContext =
         source.path(ENTITY_DESCRIPTION).path(REFERENCE).path(PUBLICATION_CONTEXT);
 
+    var doiNode = extractDoi(source);
+
     return new PublishingDetails(
         NodeUtils.toUri(publicationContext.path(ID)),
         publicationContext.path(TYPE).textValue(),
         publicationContext.path(NAME).textValue(),
-        NodeUtils.toUri(source.path(ENTITY_DESCRIPTION).path(REFERENCE).path(DOI)),
+        NodeUtils.toUri(doiNode),
         fromNodeRating(publicationContext.path(SERIES)),
         fromNodeRating(publicationContext.path(PUBLISHER)));
+  }
+
+  private JsonNode extractDoi(JsonNode source) {
+    return Optional.of(source.path(ENTITY_DESCRIPTION).path(REFERENCE).path(DOI))
+        .filter(node -> !node.isMissingNode())
+        .orElse(source.path(DOI));
   }
 
   private ScientificRating fromNodeRating(JsonNode node) {

--- a/search-commons/src/main/java/no/unit/nva/search/resource/response/ResourceSearchResponse.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/response/ResourceSearchResponse.java
@@ -14,7 +14,6 @@ import java.util.Map;
 public record ResourceSearchResponse(
     URI id,
     String identifier,
-    URI doi,
     String type,
     URI language,
     OtherIdentifiers otherIdentifiers,
@@ -78,11 +77,6 @@ public record ResourceSearchResponse(
       return this;
     }
 
-    public Builder withDoi(URI doi) {
-      this.doi = doi;
-      return this;
-    }
-
     public Builder withOtherIdentifiers(OtherIdentifiers otherIdentifiers) {
       this.otherIdentifiers = otherIdentifiers;
       return this;
@@ -137,7 +131,6 @@ public record ResourceSearchResponse(
       return new ResourceSearchResponse(
           id,
           identifier,
-          doi,
           type,
           language,
           otherIdentifiers,


### PR DESCRIPTION
Simplified resource search response model now falls back to NVA-issued doi (`publication.doi`) if reference DOI (`publication.entityDescription.refererence.doi`) is not present. With this change, OAI-PMH never exposes more than one DOI as identifier.