### PR TITLE
now maps description to dc:description

### DIFF
--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandler.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandler.java
@@ -59,7 +59,7 @@ public class OaiPmhHandler extends ApiGatewayHandler<String, String> {
   @JacocoGenerated
   private static OaiPmhMethodRouter defaultOaiPmhMethodRouter() {
     var environment = new Environment();
-    var batchSize = environment.readEnvOpt("LIST_RECORDS_BATCH_SIZE").orElse("250");
+    var batchSize = environment.readEnvOpt("LIST_RECORDS_BATCH_SIZE").orElse("50");
     return new DefaultOaiPmhMethodRouter(
         new ResourceClientResourceRepository(ResourceClient.defaultClient()),
         Integer.parseInt(batchSize),

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/transformers/SimplifiedRecordTransformer.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/oaipmh/transformers/SimplifiedRecordTransformer.java
@@ -69,10 +69,15 @@ public class SimplifiedRecordTransformer implements RecordTransformer {
   }
 
   private static void appendDescriptions(ResourceSearchResponse response, OaiDcType oaiDcType) {
-    var mainLanguageAbstract = sanitizeXmlValue(response.mainLanguageAbstract());
-    if (!StringUtils.isEmpty(mainLanguageAbstract)) {
+    appendSanitizedDcDescription(response.mainLanguageAbstract(), oaiDcType);
+    appendSanitizedDcDescription(response.description(), oaiDcType);
+  }
+
+  private static void appendSanitizedDcDescription(String value, OaiDcType oaiDcType) {
+    var sanitizedValue = sanitizeXmlValue(value);
+    if (StringUtils.isNotEmpty(sanitizedValue)) {
       var descriptionElement = OBJECT_FACTORY.createElementType();
-      descriptionElement.setValue(mainLanguageAbstract);
+      descriptionElement.setValue(sanitizedValue);
       oaiDcType
           .getTitleOrCreatorOrSubject()
           .addLast(OBJECT_FACTORY.createDescription(descriptionElement));

--- a/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandlerTest.java
+++ b/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandlerTest.java
@@ -143,6 +143,7 @@ public class OaiPmhHandlerTest {
   private static final String PUBLICATION_MONTH = "01";
   private static final String PUBLICATION_DAY = "01";
   private static final String RESOURCE_ABSTRACT = "My abstract";
+  private static final String RESOURCE_DESCRIPTION = "My description";
 
   private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
   private Environment environment;
@@ -739,6 +740,15 @@ public class OaiPmhHandlerTest {
   }
 
   @Test
+  void shouldMapDescriptionToRecordMetadataDcDescription() throws IOException, JAXBException {
+    var inputStream = defaultHitAndRequest();
+
+    var response = invokeHandlerAndAssertHttpStatusCodeOk(inputStream);
+
+    assertHasDescription(response, RESOURCE_DESCRIPTION);
+  }
+
+  @Test
   void shouldPopulateReferenceDoiAsDcIdentifier() throws IOException, JAXBException {
     var inputStream = bookAnthologyRequest();
 
@@ -1326,6 +1336,7 @@ public class OaiPmhHandlerTest {
     return ResourceDocumentFactory.builder(
             RESOURCE_ID, RESOURCE_TITLE, PUBLICATION_YEAR, PUBLICATION_MONTH, PUBLICATION_DAY)
         .withAbstract(RESOURCE_ABSTRACT)
+        .withDescription(RESOURCE_DESCRIPTION)
         .withAdditionalIdentifier(CRISTIN_AS_TYPE, CRISTIN_IDENTIFIER)
         .withAdditionalIdentifier(SCOPUS_AS_TYPE, SCOPUS_IDENTIFIER)
         .withAdditionalIdentifier("HandleIdentifier", HANDLE_IDENTIFIER)

--- a/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/data/ResourceDocumentFactory.java
+++ b/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/data/ResourceDocumentFactory.java
@@ -16,6 +16,7 @@ public class ResourceDocumentFactory {
   private static ObjectNode entityDescription(
       String title,
       String resourceAbstract,
+      String description,
       URI language,
       ObjectNode referenceNode,
       ObjectNode publicationDateNode,
@@ -28,7 +29,12 @@ public class ResourceDocumentFactory {
     entityDescriptionNode.set("publicationDate", publicationDateNode);
     entityDescriptionNode.set("reference", referenceNode);
     entityDescriptionNode.set("contributors", contributorsNode);
-    entityDescriptionNode.put("abstract", resourceAbstract);
+    if (nonNull(description)) {
+      entityDescriptionNode.put("description", description);
+    }
+    if (nonNull(resourceAbstract)) {
+      entityDescriptionNode.put("abstract", resourceAbstract);
+    }
     return entityDescriptionNode;
   }
 
@@ -52,6 +58,7 @@ public class ResourceDocumentFactory {
     private final List<ObjectNode> contributorNodes = new ArrayList<>();
     private final List<ObjectNode> additionalIdentifierNodes = new ArrayList<>();
     private String resourceAbstract;
+    private String description;
     private ObjectNode referenceNode;
     private URI language;
 
@@ -106,6 +113,11 @@ public class ResourceDocumentFactory {
       return this;
     }
 
+    public ResourceDocumentBuilder withDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
     void applyType(ObjectNode referenceNode) {
       this.referenceNode = referenceNode;
     }
@@ -131,6 +143,7 @@ public class ResourceDocumentFactory {
           entityDescription(
               title,
               resourceAbstract,
+              description,
               language,
               referenceNode,
               publicationDateNode,


### PR DESCRIPTION
Also adjusted default batch size in ListRecords to 50 which seems to be a more sensible default given AWS event body restrictions and the increasing amount of metadata returned per record