### PR TITLE
Np 49616 contributing organizations

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/resource/SimplifiedMutator.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/SimplifiedMutator.java
@@ -54,7 +54,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;

--- a/search-commons/src/main/java/no/unit/nva/search/resource/SimplifiedMutator.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/SimplifiedMutator.java
@@ -14,6 +14,7 @@ import static no.unit.nva.constants.Words.ID;
 import static no.unit.nva.constants.Words.IDENTIFIER;
 import static no.unit.nva.constants.Words.IDENTITY;
 import static no.unit.nva.constants.Words.ISBN_LIST;
+import static no.unit.nva.constants.Words.LABELS;
 import static no.unit.nva.constants.Words.LANGUAGE;
 import static no.unit.nva.constants.Words.MAIN_TITLE;
 import static no.unit.nva.constants.Words.MODIFIED_DATE;
@@ -32,6 +33,7 @@ import static no.unit.nva.constants.Words.ROLE;
 import static no.unit.nva.constants.Words.SERIES;
 import static no.unit.nva.constants.Words.STATUS;
 import static no.unit.nva.constants.Words.TAGS;
+import static no.unit.nva.constants.Words.TOP_LEVEL_ORGANIZATIONS;
 import static no.unit.nva.constants.Words.TYPE;
 import static no.unit.nva.constants.Words.VALUE;
 import static no.unit.nva.constants.Words.YEAR;
@@ -68,6 +70,7 @@ import no.unit.nva.search.resource.response.Affiliation;
 import no.unit.nva.search.resource.response.Contributor;
 import no.unit.nva.search.resource.response.Identity;
 import no.unit.nva.search.resource.response.NodeUtils;
+import no.unit.nva.search.resource.response.Organization;
 import no.unit.nva.search.resource.response.OtherIdentifiers;
 import no.unit.nva.search.resource.response.PublicationDate;
 import no.unit.nva.search.resource.response.PublishingDetails;
@@ -108,7 +111,8 @@ public class SimplifiedMutator implements JsonNodeMutator {
         PUBLISHED_DATE,
         DOI,
         HANDLE,
-        CURATING_INSTITUTIONS,
+        CURATING_INSTITUTIONS, // consider removing
+        path(TOP_LEVEL_ORGANIZATIONS, ID, LABELS),
         path(ENTITY_DESCRIPTION, REFERENCE, PUBLICATION_INSTANCE, TYPE),
         path(ENTITY_DESCRIPTION, REFERENCE, PUBLICATION_INSTANCE, MANIFESTATIONS, ISBN_LIST),
         path(ENTITY_DESCRIPTION, REFERENCE, DOI),
@@ -165,21 +169,16 @@ public class SimplifiedMutator implements JsonNodeMutator {
         .build();
   }
 
-  private Set<URI> extractParticipatingOrganizations(JsonNode source) {
-    var curatingInstitutions = source.path(CURATING_INSTITUTIONS);
-    if (curatingInstitutions.isMissingNode() || !curatingInstitutions.isArray()) {
+  private Set<Organization> extractParticipatingOrganizations(JsonNode source) {
+    var topLevelOrganizations = source.path(TOP_LEVEL_ORGANIZATIONS);
+    if (topLevelOrganizations.isMissingNode() || !topLevelOrganizations.isArray()) {
       return Collections.emptySet();
     }
 
-    var participatingOrganizations = new HashSet<URI>();
-    curatingInstitutions.forEach(
-        node -> this.appendParticipatingOrganization(participatingOrganizations, node));
+    var participatingOrganizations = new HashSet<Organization>();
+    topLevelOrganizations.forEach(
+        node -> participatingOrganizations.add(Organization.fromJsonNode(node)));
     return participatingOrganizations;
-  }
-
-  private void appendParticipatingOrganization(
-      Set<URI> participatingOrganizations, JsonNode curatingInstitutionNode) {
-    participatingOrganizations.add(URI.create(curatingInstitutionNode.asText()));
   }
 
   private Set<String> fromNodeToTags(JsonNode tagsNode) {

--- a/search-commons/src/main/java/no/unit/nva/search/resource/response/Organization.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/response/Organization.java
@@ -1,0 +1,14 @@
+package no.unit.nva.search.resource.response;
+
+import static nva.commons.core.attempt.Try.attempt;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URI;
+import java.util.Map;
+import no.unit.nva.commons.json.JsonUtils;
+
+public record Organization(URI id, Map<String, String> labels) {
+
+  public static Organization fromJsonNode(JsonNode node) {
+    return attempt(() -> JsonUtils.dtoObjectMapper.treeToValue(node, Organization.class)).orElseThrow();
+  }
+}

--- a/search-commons/src/main/java/no/unit/nva/search/resource/response/Organization.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/response/Organization.java
@@ -1,6 +1,7 @@
 package no.unit.nva.search.resource.response;
 
 import static nva.commons.core.attempt.Try.attempt;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
 import java.util.Map;
@@ -9,6 +10,7 @@ import no.unit.nva.commons.json.JsonUtils;
 public record Organization(URI id, Map<String, String> labels) {
 
   public static Organization fromJsonNode(JsonNode node) {
-    return attempt(() -> JsonUtils.dtoObjectMapper.treeToValue(node, Organization.class)).orElseThrow();
+    return attempt(() -> JsonUtils.dtoObjectMapper.treeToValue(node, Organization.class))
+        .orElseThrow();
   }
 }

--- a/search-commons/src/main/java/no/unit/nva/search/resource/response/ResourceSearchResponse.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/response/ResourceSearchResponse.java
@@ -29,7 +29,7 @@ public record ResourceSearchResponse(
     int contributorsCount,
     PublishingDetails publishingDetails,
     Set<String> tags,
-    Set<URI> participatingOrganizations) {
+    Set<Organization> participatingOrganizations) {
 
   public static Builder responseBuilder() {
     return new Builder();
@@ -53,7 +53,7 @@ public record ResourceSearchResponse(
     private int contributorsCount;
     private PublishingDetails publishingDetails;
     private Set<String> tags = Collections.emptySet();
-    private Set<URI> participatingOrganizations = Collections.emptySet();
+    private Set<Organization> participatingOrganizations = Collections.emptySet();
 
     private Builder() {}
 
@@ -138,7 +138,7 @@ public record ResourceSearchResponse(
       return this;
     }
 
-    public Builder withParticipatingOrganizations(Set<URI> participatingOrganizations) {
+    public Builder withParticipatingOrganizations(Set<Organization> participatingOrganizations) {
       this.participatingOrganizations = participatingOrganizations;
       return this;
     }


### PR DESCRIPTION
- `participatingOrganizations` er nå et array av objekter og ikke bare URI'er (`id` og `labels` fra `topLevelOrganizations`)
- record metadata inneholder nå dc:contributor-elementer med navn på organisasjon (prioriter label med en -> nb -> nn, fallback til identifier)