### PR TITLE
feat: Add indexDocumentCreatedAt timestamp

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/indexingclient/models/IndexDocument.java
+++ b/search-commons/src/main/java/no/unit/nva/indexingclient/models/IndexDocument.java
@@ -32,10 +32,11 @@ public record IndexDocument(
   static final String IMPORT_CANDIDATE = "ImportCandidate";
   static final String TICKET = "Ticket";
   static final String RESOURCE = "Resource";
+  private static final String INDEX_DOCUMENT_CREATED_AT = "indexDocumentCreatedAt";
 
   public IndexDocument {
-    if (resource instanceof ObjectNode objectNode && !objectNode.has("indexDocumentCreatedAt")) {
-      objectNode.put("indexDocumentCreatedAt", Instant.now().toString());
+    if (resource instanceof ObjectNode objectNode && !objectNode.has(INDEX_DOCUMENT_CREATED_AT)) {
+      objectNode.put(INDEX_DOCUMENT_CREATED_AT, Instant.now().toString());
     }
   }
 

--- a/search-commons/src/main/java/no/unit/nva/indexingclient/models/IndexDocument.java
+++ b/search-commons/src/main/java/no/unit/nva/indexingclient/models/IndexDocument.java
@@ -14,6 +14,8 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import no.unit.nva.commons.json.JsonSerializable;
@@ -30,6 +32,12 @@ public record IndexDocument(
   static final String IMPORT_CANDIDATE = "ImportCandidate";
   static final String TICKET = "Ticket";
   static final String RESOURCE = "Resource";
+
+  public IndexDocument {
+    if (resource instanceof ObjectNode objectNode && !objectNode.has("indexDocumentCreatedAt")) {
+      objectNode.put("indexDocumentCreatedAt", Instant.now().toString());
+    }
+  }
 
   public static IndexDocument fromJsonString(String json) {
     return attempt(() -> objectMapperWithEmpty.readValue(json, IndexDocument.class)).orElseThrow();

--- a/search-commons/src/main/resources/indices/import_candidate/mappings.json
+++ b/search-commons/src/main/resources/indices/import_candidate/mappings.json
@@ -24,6 +24,9 @@
     "additionalIdentifiers": {
       "type": "nested",
       "include_in_parent": true
+    },
+    "indexDocumentCreatedAt": {
+      "type": "date"
     }
   }
 }

--- a/search-commons/src/main/resources/indices/resource/mappings.json
+++ b/search-commons/src/main/resources/indices/resource/mappings.json
@@ -120,6 +120,9 @@
       "relations": {
         "hasParts": "partOf"
       }
+    },
+    "indexDocumentCreatedAt": {
+      "type": "date"
     }
   }
 }

--- a/search-commons/src/main/resources/indices/ticket/mappings.json
+++ b/search-commons/src/main/resources/indices/ticket/mappings.json
@@ -45,6 +45,9 @@
           "type": "flat_object"
         }
       }
+    },
+    "indexDocumentCreatedAt": {
+      "type": "date"
     }
   }
 }


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49736

Adds a timestamp to all index documents to indicate when it was processed. This is intended to make it easier to clean up orphaned index documents later and to check that all documents have been processed after we redistribute documents between shards.