### PR TITLE
ci: Add Docker hub config

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -4,6 +4,9 @@ env:
   variables:
     GRADLE_USER_HOME: '/root/.gradle'
     SAM_CLI_TELEMETRY: "0"
+  secrets-manager:
+    DOCKER_HUB_USERNAME: DockerHubCredentials:DockerHubUsername
+    DOCKER_HUB_SECRET: DockerHubCredentials:DockerHubSecret
 
 cache:
   paths:
@@ -29,6 +32,11 @@ phases:
           echo "AWS SAM CLI is not installed, installing now";
           pip3 install aws-sam-cli
         fi
+  pre_build:
+    commands:
+      # We need to be logged in to Docker Hub to pull images for testcontainers
+      - echo "Logging in to Docker Hub..."
+      - echo -n "$DOCKER_HUB_SECRET" | docker login --username $DOCKER_HUB_USERNAME --password-stdin
   build:
     commands:
       - ./gradlew test


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49747

This copies the configuration of `buildspec.yaml` from `nva-nvi` in order to use our DockerHub credentials when pulling images during build, which may be necessary to avoid rate limits. Hopefully this fixes failing builds in CodeBuild.