### PR TITLE
build: Upgrade OpenSearch image in tests to 2.19.5

### DIFF
--- a/search-commons/src/test/java/no/unit/nva/common/Containers.java
+++ b/search-commons/src/test/java/no/unit/nva/common/Containers.java
@@ -2,7 +2,6 @@ package no.unit.nva.common;
 
 import static java.util.Objects.nonNull;
 import static no.unit.nva.common.TestConstants.DELAY_AFTER_INDEXING;
-import static no.unit.nva.common.TestConstants.OPEN_SEARCH_IMAGE;
 import static no.unit.nva.constants.IndexMappingsAndSettings.IMPORT_CANDIDATE_MAPPINGS;
 import static no.unit.nva.constants.IndexMappingsAndSettings.RESOURCE_MAPPINGS;
 import static no.unit.nva.constants.IndexMappingsAndSettings.RESOURCE_SETTINGS;
@@ -11,6 +10,7 @@ import static no.unit.nva.constants.Words.IDENTIFIER;
 import static no.unit.nva.constants.Words.IMPORT_CANDIDATES_INDEX;
 import static no.unit.nva.constants.Words.RESOURCES;
 import static no.unit.nva.constants.Words.TICKETS;
+import static no.unit.nva.indexing.testutils.Constants.OPEN_SEARCH_IMAGE;
 import static no.unit.nva.indexing.testutils.MockedJwtProvider.setupMockedCachedJwtProvider;
 import static nva.commons.core.attempt.Try.attempt;
 import static nva.commons.core.ioutils.IoUtils.stringFromResources;

--- a/search-commons/src/test/java/no/unit/nva/common/TestConstants.java
+++ b/search-commons/src/test/java/no/unit/nva/common/TestConstants.java
@@ -4,7 +4,6 @@ import nva.commons.core.JacocoGenerated;
 
 public class TestConstants {
 
-  public static final String OPEN_SEARCH_IMAGE = "opensearchproject/opensearch:2.11.0";
   public static final long DELAY_AFTER_INDEXING = 1000L;
 
   @JacocoGenerated

--- a/search-handlers/src/test/java/no/unit/nva/search/ResourceSearchContainerTests.java
+++ b/search-handlers/src/test/java/no/unit/nva/search/ResourceSearchContainerTests.java
@@ -2,6 +2,7 @@ package no.unit.nva.search;
 
 import static no.unit.nva.constants.IndexMappingsAndSettings.RESOURCE_MAPPINGS;
 import static no.unit.nva.constants.IndexMappingsAndSettings.RESOURCE_SETTINGS;
+import static no.unit.nva.indexing.testutils.Constants.OPEN_SEARCH_IMAGE;
 import static no.unit.nva.indexing.testutils.MockedJwtProvider.setupMockedCachedJwtProvider;
 import static no.unit.nva.search.common.enums.PublicationStatus.PUBLISHED;
 import static no.unit.nva.search.common.enums.PublicationStatus.PUBLISHED_METADATA;
@@ -52,7 +53,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 class ResourceSearchContainerTests {
 
-  private static final String OPEN_SEARCH_IMAGE = "opensearchproject/opensearch:2.11.0";
   private static final OpenSearchContainer<?> container =
       new OpenSearchContainer<>(OPEN_SEARCH_IMAGE);
   private static final String INDEX_NAME = "resources";

--- a/search-testing/src/main/java/no/unit/nva/indexing/testutils/Constants.java
+++ b/search-testing/src/main/java/no/unit/nva/indexing/testutils/Constants.java
@@ -3,6 +3,7 @@ package no.unit.nva.indexing.testutils;
 import nva.commons.core.JacocoGenerated;
 
 public final class Constants {
+  public static final String OPEN_SEARCH_IMAGE = "opensearchproject/opensearch:2.19.5";
   public static final String TEST_SCOPE = "example-scope";
   public static final String TEST_TOKEN =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2Njg1MTE4NTcsImV4cCI6MTcw"


### PR DESCRIPTION
Upgrades the container version of OpenSearch server used in integration tests to 2.19.5. This is the most recent minor version available. Given that this works, we should upgrade the actual OpenSearch cluster to match.