### PR TITLE
[np-51039] refactor: Extract and simplify reused validation

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/common/ParameterValidator.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/ParameterValidator.java
@@ -1,6 +1,8 @@
 package no.unit.nva.search.common;
 
 import static java.util.Objects.isNull;
+import static no.unit.nva.constants.Defaults.DEFAULT_OFFSET;
+import static no.unit.nva.constants.Defaults.DEFAULT_VALUE_PER_PAGE;
 import static no.unit.nva.constants.ErrorMessages.INVALID_VALUE_WITH_SORT;
 import static no.unit.nva.constants.ErrorMessages.PAGINATION_PARAMETERS_ARE_MUTUAL_EXCLUSIVE;
 import static no.unit.nva.constants.ErrorMessages.RELEVANCE_SEARCH_AFTER_ARE_MUTUAL_EXCLUSIVE;
@@ -12,10 +14,12 @@ import static no.unit.nva.constants.Words.ALL;
 import static no.unit.nva.constants.Words.COMMA;
 import static no.unit.nva.constants.Words.HTTPS;
 import static no.unit.nva.constants.Words.NAME_AND_SORT_LENGTH;
+import static no.unit.nva.constants.Words.NONE;
 import static no.unit.nva.constants.Words.RELEVANCE_KEY_NAME;
 import static no.unit.nva.search.common.ContentTypeUtils.extractContentTypeFromRequestInfo;
 import static no.unit.nva.search.common.constant.Functions.decodeUTF;
 import static no.unit.nva.search.common.constant.Functions.mergeWithColonOrComma;
+import static no.unit.nva.search.common.constant.Functions.trimSpace;
 import static no.unit.nva.search.common.constant.Patterns.COLON_OR_SPACE;
 import static nva.commons.core.StringUtils.EMPTY_STRING;
 
@@ -50,6 +54,14 @@ public abstract class ParameterValidator<
   protected static final Logger logger = LoggerFactory.getLogger(ParameterValidator.class);
 
   private static final int MAX_RESULT_WINDOW_SIZE = 10_000;
+  private static final String FROM_KEY_NAME = "FROM";
+  private static final String SIZE_KEY_NAME = "SIZE";
+  private static final String PAGE_KEY_NAME = "PAGE";
+  private static final String SORT_KEY_NAME = "SORT";
+  private static final String SORT_ORDER_KEY_NAME = "SORT_ORDER";
+  private static final String AGGREGATION_KEY_NAME = "AGGREGATION";
+  private static final String SEARCH_AFTER_KEY_NAME = "SEARCH_AFTER";
+  private static final String NODES_SEARCHED_KEY_NAME = "NODES_SEARCHED";
   protected final transient Set<String> invalidKeys = new HashSet<>(0);
   protected final transient SearchQuery<K> query;
   protected transient boolean notValidated = true;
@@ -108,24 +120,56 @@ public abstract class ParameterValidator<
   }
 
   /**
-   * DefaultValues are only assigned if they are set as required, otherwise ignored.
-   *
-   * <p>Usage: <samp>requiredMissing().forEach(key -> { <br>
-   * switch (key) {<br>
-   * case LANGUAGE -> query.setValue(key, DEFAULT_LANGUAGE_CODE);<br>
-   * default -> { // do nothing }<br>
-   * }});<br>
-   * </samp>
+   * Assigns defaults for required-but-missing pagination, sort and aggregation keys. Subclasses
+   * override {@link #getDefaultSort()} to change the default sort; other defaults are fixed.
    */
-  protected abstract void assignDefaultValues();
+  protected void assignDefaultValues() {
+    requiredMissing()
+        .forEach(
+            key -> {
+              switch (key.name()) {
+                case FROM_KEY_NAME -> setValue(key.name(), DEFAULT_OFFSET);
+                case SIZE_KEY_NAME -> setValue(key.name(), DEFAULT_VALUE_PER_PAGE);
+                case SORT_KEY_NAME -> setValue(key.name(), getDefaultSort());
+                case AGGREGATION_KEY_NAME -> setValue(key.name(), NONE);
+                default -> {}
+              }
+            });
+  }
 
-  protected abstract void applyRulesAfterValidation();
+  /** Default sort applied when SORT is required but missing. Override to customize. */
+  protected String getDefaultSort() {
+    return RELEVANCE_KEY_NAME;
+  }
+
+  /**
+   * Runs the shared page-to-offset conversion, then delegates to {@link
+   * #applyAdditionalRulesAfterValidation()} for type-specific rules.
+   */
+  protected void applyRulesAfterValidation() {
+    convertPageToOffsetIfNeeded();
+    applyAdditionalRulesAfterValidation();
+  }
+
+  /** Hook for type-specific post-validation rules (e.g. business-rule parameter coupling). */
+  protected abstract void applyAdditionalRulesAfterValidation();
+
+  private void convertPageToOffsetIfNeeded() {
+    var pageKey = query.toKey(PAGE_KEY_NAME);
+    if (query.parameters().isPresent(pageKey)) {
+      var fromKey = query.toKey(FROM_KEY_NAME);
+      if (query.parameters().isPresent(fromKey)) {
+        var page = query.parameters().get(pageKey).<Number>as().longValue();
+        var perPage = query.parameters().get(query.toKey(SIZE_KEY_NAME)).<Number>as().longValue();
+        query.parameters().set(fromKey, String.valueOf(page * perPage));
+      }
+      query.parameters().remove(pageKey);
+    }
+  }
 
   protected abstract Collection<String> validKeys();
 
   protected abstract Collection<String> validSortKeys();
-
-  protected abstract boolean isKeyValid(String keyName);
 
   protected void validateSortKeyName(String name) {
     var nameSort = name.split(COLON_OR_SPACE);
@@ -140,17 +184,39 @@ public abstract class ParameterValidator<
   }
 
   /**
-   * Sample code for setValue.
-   *
-   * <p>Usage: <samp>var qpKey = keyFromString(key,value);<br>
-   * if(qpKey.equals(INVALID)) {<br>
-   * invalidKeys.add(key);<br>
-   * } else {<br>
-   * query.setValue(qpKey, value);<br>
-   * }<br>
-   * </samp>
+   * Decodes and stores a parameter value. Unrecognized keys are collected in {@link #invalidKeys}
+   * (reported later as a batch). Pagination, sort, sort-order and field-filter keys have shared
+   * handling here; anything else is delegated to {@link #setValueSpecific(Enum, String)}.
    */
-  protected abstract void setValue(String key, String value);
+  protected void setValue(String key, String value) {
+    var qpKey = query.toKey(key);
+    if (qpKey.isInvalid()) {
+      invalidKeys.add(key);
+    } else {
+      var decodedValue = getDecodedValue(qpKey, value);
+      switch (qpKey.name()) {
+        case SEARCH_AFTER_KEY_NAME,
+            FROM_KEY_NAME,
+            SIZE_KEY_NAME,
+            PAGE_KEY_NAME,
+            AGGREGATION_KEY_NAME ->
+            query.parameters().set(qpKey, decodedValue);
+        case NODES_SEARCHED_KEY_NAME ->
+            query.parameters().set(qpKey, ignoreInvalidFields(decodedValue));
+        case SORT_KEY_NAME -> mergeToKey(qpKey, trimSpace(decodedValue));
+        case SORT_ORDER_KEY_NAME -> mergeToKey(query.toKey(SORT_KEY_NAME), decodedValue);
+        default -> setValueSpecific(qpKey, decodedValue);
+      }
+    }
+  }
+
+  /**
+   * Hook for type-specific parameter handling (e.g. URI transformation, enum conversion). Override
+   * to transform the value before storing it under its key.
+   */
+  protected void setValueSpecific(K qpKey, String decodedValue) {
+    mergeToKey(qpKey, decodedValue);
+  }
 
   /**
    * Validate sort keys.
@@ -308,7 +374,7 @@ public abstract class ParameterValidator<
     return ALL.equalsIgnoreCase(value) || isNull(value)
         ? ALL
         : Arrays.stream(value.split(COMMA))
-            .filter(this::isKeyValid) // ignoring invalid keys
+            .filter(name -> query.toKey(name).isValid())
             .collect(Collectors.joining(COMMA));
   }
 

--- a/search-commons/src/main/java/no/unit/nva/search/common/ParameterValidator.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/ParameterValidator.java
@@ -186,7 +186,7 @@ public abstract class ParameterValidator<
   /**
    * Decodes and stores a parameter value. Unrecognized keys are collected in {@link #invalidKeys}
    * (reported later as a batch). Pagination, sort, sort-order and field-filter keys have shared
-   * handling here; anything else is delegated to {@link #setValueSpecific(Enum, String)}.
+   * handling here; anything else is delegated to {@link #setCustomValue(Enum, String)}.
    */
   protected void setValue(String key, String value) {
     var qpKey = query.toKey(key);
@@ -205,7 +205,7 @@ public abstract class ParameterValidator<
             query.parameters().set(qpKey, ignoreInvalidFields(decodedValue));
         case SORT_KEY_NAME -> mergeToKey(qpKey, trimSpace(decodedValue));
         case SORT_ORDER_KEY_NAME -> mergeToKey(query.toKey(SORT_KEY_NAME), decodedValue);
-        default -> setValueSpecific(qpKey, decodedValue);
+        default -> setCustomValue(qpKey, decodedValue);
       }
     }
   }
@@ -214,7 +214,7 @@ public abstract class ParameterValidator<
    * Hook for type-specific parameter handling (e.g. URI transformation, enum conversion). Override
    * to transform the value before storing it under its key.
    */
-  protected void setValueSpecific(K qpKey, String decodedValue) {
+  protected void setCustomValue(K qpKey, String decodedValue) {
     mergeToKey(qpKey, decodedValue);
   }
 

--- a/search-commons/src/main/java/no/unit/nva/search/common/enums/ParameterKey.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/enums/ParameterKey.java
@@ -79,6 +79,16 @@ public interface ParameterKey<K extends Enum<K> & ParameterKey<K>> {
     return isKeyWord.length == 1 ? !isKeyWord[0] : result;
   }
 
+  String name();
+
+  default boolean isInvalid() {
+    return "INVALID".equals(name());
+  }
+
+  default boolean isValid() {
+    return !isInvalid();
+  }
+
   String asCamelCase();
 
   String asLowerCase();

--- a/search-commons/src/main/java/no/unit/nva/search/common/enums/SortKey.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/enums/SortKey.java
@@ -37,6 +37,10 @@ public interface SortKey {
     return INVALID_SORT_KEY_NAME.equals(name());
   }
 
+  default boolean isValid() {
+    return !isInvalid();
+  }
+
   String keyPattern();
 
   Stream<String> jsonPaths();

--- a/search-commons/src/main/java/no/unit/nva/search/common/enums/SortKey.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/enums/SortKey.java
@@ -37,10 +37,6 @@ public interface SortKey {
     return INVALID_SORT_KEY_NAME.equals(name());
   }
 
-  default boolean isValid() {
-    return !isInvalid();
-  }
-
   String keyPattern();
 
   Stream<String> jsonPaths();

--- a/search-commons/src/main/java/no/unit/nva/search/importcandidate/ImportCandidateSearchQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/importcandidate/ImportCandidateSearchQuery.java
@@ -1,19 +1,14 @@
 package no.unit.nva.search.importcandidate;
 
-import static no.unit.nva.constants.Defaults.DEFAULT_OFFSET;
-import static no.unit.nva.constants.Defaults.DEFAULT_VALUE_PER_PAGE;
 import static no.unit.nva.constants.Words.ADDITIONAL_IDENTIFIERS;
 import static no.unit.nva.constants.Words.COMMA;
 import static no.unit.nva.constants.Words.CRISTIN_AS_TYPE;
 import static no.unit.nva.constants.Words.KEYWORD;
-import static no.unit.nva.constants.Words.NONE;
-import static no.unit.nva.constants.Words.RELEVANCE_KEY_NAME;
 import static no.unit.nva.constants.Words.SCOPUS_AS_TYPE;
 import static no.unit.nva.constants.Words.SEARCH;
 import static no.unit.nva.constants.Words.TYPE;
 import static no.unit.nva.constants.Words.VALUE;
 import static no.unit.nva.search.common.constant.Functions.jsonPath;
-import static no.unit.nva.search.common.constant.Functions.trimSpace;
 import static no.unit.nva.search.importcandidate.Constants.FACET_IMPORT_CANDIDATE_PATHS;
 import static no.unit.nva.search.importcandidate.Constants.IMPORT_CANDIDATES_AGGREGATIONS;
 import static no.unit.nva.search.importcandidate.Constants.IMPORT_CANDIDATES_INDEX_NAME;
@@ -174,37 +169,6 @@ public final class ImportCandidateSearchQuery extends SearchQuery<ImportCandidat
     }
 
     @Override
-    protected void assignDefaultValues() {
-      requiredMissing()
-          .forEach(
-              key -> {
-                switch (key) {
-                  case FROM -> setValue(key.name(), DEFAULT_OFFSET);
-                  case SIZE -> setValue(key.name(), DEFAULT_VALUE_PER_PAGE);
-                  case SORT -> setValue(key.name(), RELEVANCE_KEY_NAME);
-                  case AGGREGATION -> setValue(key.name(), NONE);
-                  default -> {
-                    /* do nothing */
-                  }
-                }
-              });
-    }
-
-    @JacocoGenerated
-    @Override
-    protected void applyRulesAfterValidation() {
-      // convert page to offset if offset is not set
-      if (query.parameters().isPresent(PAGE)) {
-        if (query.parameters().isPresent(FROM)) {
-          var page = query.parameters().get(PAGE).<Number>as();
-          var perPage = query.parameters().get(SIZE).<Number>as();
-          query.parameters().set(FROM, String.valueOf(page.longValue() * perPage.longValue()));
-        }
-        query.parameters().remove(PAGE);
-      }
-    }
-
-    @Override
     protected Collection<String> validKeys() {
       return IMPORT_CANDIDATE_PARAMETER_SET.stream()
           .map(ImportCandidateParameter::asLowerCase)
@@ -217,24 +181,6 @@ public final class ImportCandidateSearchQuery extends SearchQuery<ImportCandidat
     }
 
     @Override
-    protected void setValue(String key, String value) {
-      var qpKey = ImportCandidateParameter.keyFromString(key);
-      var decodedValue = getDecodedValue(qpKey, value);
-
-      switch (qpKey) {
-        case SEARCH_AFTER, FROM, SIZE, PAGE, AGGREGATION ->
-            query.parameters().set(qpKey, decodedValue);
-        case NODES_SEARCHED -> query.parameters().set(qpKey, ignoreInvalidFields(decodedValue));
-        case SORT -> mergeToKey(SORT, trimSpace(decodedValue));
-        case SORT_ORDER -> mergeToKey(SORT, decodedValue);
-        case INVALID -> invalidKeys.add(key);
-        default -> mergeToKey(qpKey, decodedValue);
-      }
-    }
-
-    @Override
-    protected boolean isKeyValid(String keyName) {
-      return ImportCandidateParameter.keyFromString(keyName) != ImportCandidateParameter.INVALID;
-    }
+    protected void applyAdditionalRulesAfterValidation() {}
   }
 }

--- a/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSearchQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSearchQuery.java
@@ -1,18 +1,13 @@
 package no.unit.nva.search.resource;
 
 import static java.lang.String.format;
-import static no.unit.nva.constants.Defaults.DEFAULT_OFFSET;
-import static no.unit.nva.constants.Defaults.DEFAULT_VALUE_PER_PAGE;
 import static no.unit.nva.constants.Words.COMMA;
 import static no.unit.nva.constants.Words.CRISTIN_AS_TYPE;
 import static no.unit.nva.constants.Words.HTTPS;
 import static no.unit.nva.constants.Words.IDENTIFIER;
-import static no.unit.nva.constants.Words.NONE;
 import static no.unit.nva.constants.Words.PI;
-import static no.unit.nva.constants.Words.RELEVANCE_KEY_NAME;
 import static no.unit.nva.constants.Words.SCOPUS_AS_TYPE;
 import static no.unit.nva.constants.Words.STATUS;
-import static no.unit.nva.search.common.constant.Functions.trimSpace;
 import static no.unit.nva.search.resource.Constants.CRISTIN_ORGANIZATION_PATH;
 import static no.unit.nva.search.resource.Constants.CRISTIN_PERSON_PATH;
 import static no.unit.nva.search.resource.Constants.GLOBAL_EXCLUDED_FIELDS;
@@ -280,44 +275,8 @@ public final class ResourceSearchQuery extends SearchQuery<ResourceParameter> {
     }
 
     @Override
-    protected void assignDefaultValues() {
-      requiredMissing()
-          .forEach(
-              key -> {
-                switch (key) {
-                  case FROM -> setValue(key.name(), DEFAULT_OFFSET);
-                  case SIZE -> setValue(key.name(), DEFAULT_VALUE_PER_PAGE);
-                  case SORT -> setValue(key.name(), RELEVANCE_KEY_NAME);
-                  case AGGREGATION -> setValue(key.name(), NONE);
-                  default -> {
-                    /* ignore and continue */
-                  }
-                }
-              });
-    }
-
-    @JacocoGenerated
-    @Override
-    protected void applyRulesAfterValidation() {
-      // convert page to offset if offset is not set
-      if (query.parameters().isPresent(PAGE)) {
-        if (query.parameters().isPresent(FROM)) {
-          var page = query.parameters().get(PAGE).<Number>as();
-          var perPage = query.parameters().get(SIZE).<Number>as();
-          query.parameters().set(FROM, String.valueOf(page.longValue() * perPage.longValue()));
-        }
-        query.parameters().remove(PAGE);
-      }
-    }
-
-    @Override
     protected Collection<String> validKeys() {
       return RESOURCE_PARAMETER_SET.stream().map(ResourceParameter::asLowerCase).toList();
-    }
-
-    @Override
-    protected boolean isKeyValid(String keyName) {
-      return ResourceParameter.keyFromString(keyName) != ResourceParameter.INVALID;
     }
 
     @Override
@@ -326,20 +285,15 @@ public final class ResourceSearchQuery extends SearchQuery<ResourceParameter> {
     }
 
     @Override
-    protected void setValue(String key, String value) {
-      var qpKey = ResourceParameter.keyFromString(key);
-      var decodedValue = getDecodedValue(qpKey, value);
+    protected void applyAdditionalRulesAfterValidation() {}
+
+    @Override
+    protected void setValueSpecific(ResourceParameter qpKey, String decodedValue) {
       switch (qpKey) {
-        case INVALID -> invalidKeys.add(key);
         case UNIT, UNIT_NOT, TOP_LEVEL_ORGANIZATION ->
             mergeToKey(qpKey, identifierToCristinId(decodedValue));
         case CONTRIBUTOR, CONTRIBUTOR_NOT ->
             mergeToKey(qpKey, identifierToCristinPersonId(decodedValue));
-        case SEARCH_AFTER, FROM, SIZE, PAGE, AGGREGATION ->
-            query.parameters().set(qpKey, decodedValue);
-        case NODES_SEARCHED -> query.parameters().set(qpKey, ignoreInvalidFields(decodedValue));
-        case SORT -> mergeToKey(SORT, trimSpace(decodedValue));
-        case SORT_ORDER -> mergeToKey(SORT, decodedValue);
         default -> mergeToKey(qpKey, decodedValue);
       }
     }

--- a/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSearchQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSearchQuery.java
@@ -288,7 +288,7 @@ public final class ResourceSearchQuery extends SearchQuery<ResourceParameter> {
     protected void applyAdditionalRulesAfterValidation() {}
 
     @Override
-    protected void setValueSpecific(ResourceParameter qpKey, String decodedValue) {
+    protected void setCustomValue(ResourceParameter qpKey, String decodedValue) {
       switch (qpKey) {
         case UNIT, UNIT_NOT, TOP_LEVEL_ORGANIZATION ->
             mergeToKey(qpKey, identifierToCristinId(decodedValue));

--- a/search-commons/src/main/java/no/unit/nva/search/ticket/TicketSearchQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/ticket/TicketSearchQuery.java
@@ -289,7 +289,7 @@ public final class TicketSearchQuery extends SearchQuery<TicketParameter> {
     }
 
     @Override
-    protected void setValueSpecific(TicketParameter qpKey, String decodedValue) {
+    protected void setCustomValue(TicketParameter qpKey, String decodedValue) {
       switch (qpKey) {
         case TYPE -> mergeToKey(qpKey, toEnumStrings(TicketType::fromString, decodedValue));
         case STATUS -> mergeToKey(qpKey, toEnumStrings(TicketStatus::fromString, decodedValue));

--- a/search-commons/src/main/java/no/unit/nva/search/ticket/TicketSearchQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/ticket/TicketSearchQuery.java
@@ -1,15 +1,10 @@
 package no.unit.nva.search.ticket;
 
-import static no.unit.nva.constants.Defaults.DEFAULT_OFFSET;
-import static no.unit.nva.constants.Defaults.DEFAULT_VALUE_PER_PAGE;
 import static no.unit.nva.constants.Words.COMMA;
 import static no.unit.nva.constants.Words.EXCLUDE_KEYWORD;
-import static no.unit.nva.constants.Words.NONE;
 import static no.unit.nva.constants.Words.POST_FILTER;
-import static no.unit.nva.constants.Words.RELEVANCE_KEY_NAME;
 import static no.unit.nva.constants.Words.SEARCH;
 import static no.unit.nva.search.common.constant.Functions.toEnumStrings;
-import static no.unit.nva.search.common.constant.Functions.trimSpace;
 import static no.unit.nva.search.ticket.Constants.ORGANIZATION_ID_KEYWORD;
 import static no.unit.nva.search.ticket.Constants.STATUS_KEYWORD;
 import static no.unit.nva.search.ticket.Constants.UNHANDLED_KEY;
@@ -268,33 +263,7 @@ public final class TicketSearchQuery extends SearchQuery<TicketParameter> {
     }
 
     @Override
-    protected void assignDefaultValues() {
-      requiredMissing()
-          .forEach(
-              key -> {
-                switch (key) {
-                  case FROM -> setValue(key.name(), DEFAULT_OFFSET);
-                  case SIZE -> setValue(key.name(), DEFAULT_VALUE_PER_PAGE);
-                  case SORT -> setValue(key.name(), RELEVANCE_KEY_NAME);
-                  case AGGREGATION -> setValue(key.name(), NONE);
-                  default -> {
-                    /* ignore and continue */
-                  }
-                }
-              });
-    }
-
-    @Override
-    protected void applyRulesAfterValidation() {
-      // convert page to offset if offset is not set
-      if (query.parameters().isPresent(PAGE)) {
-        if (query.parameters().isPresent(FROM)) {
-          var page = query.parameters().get(PAGE).<Number>as().longValue();
-          var perPage = query.parameters().get(SIZE).<Number>as().longValue();
-          query.parameters().set(FROM, String.valueOf(page * perPage));
-        }
-        query.parameters().remove(PAGE);
-      }
+    protected void applyAdditionalRulesAfterValidation() {
       if (query.parameters().isPresent(BY_USER_PENDING)) {
         query.parameters().set(STATUS, PENDING.toString());
 
@@ -320,25 +289,12 @@ public final class TicketSearchQuery extends SearchQuery<TicketParameter> {
     }
 
     @Override
-    protected void setValue(String key, String value) {
-      var qpKey = TicketParameter.keyFromString(key);
-      var decodedValue = getDecodedValue(qpKey, value);
+    protected void setValueSpecific(TicketParameter qpKey, String decodedValue) {
       switch (qpKey) {
-        case INVALID -> invalidKeys.add(key);
-        case SEARCH_AFTER, FROM, SIZE, PAGE, AGGREGATION ->
-            query.parameters().set(qpKey, decodedValue);
-        case NODES_SEARCHED -> query.parameters().set(qpKey, ignoreInvalidFields(decodedValue));
-        case SORT -> mergeToKey(SORT, trimSpace(decodedValue));
-        case SORT_ORDER -> mergeToKey(SORT, decodedValue);
         case TYPE -> mergeToKey(qpKey, toEnumStrings(TicketType::fromString, decodedValue));
         case STATUS -> mergeToKey(qpKey, toEnumStrings(TicketStatus::fromString, decodedValue));
         default -> mergeToKey(qpKey, decodedValue);
       }
-    }
-
-    @Override
-    protected boolean isKeyValid(String keyName) {
-      return TicketParameter.keyFromString(keyName) != TicketParameter.INVALID;
     }
   }
 }


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-51039

Extracts and simplifies validation logic duplicated across `ResourceSearchQuery`, `TicketSearchQuery`, and `ImportCandidateSearchQuery` to the base class to make it easier to maintain.