### PR TITLE
fix(oai-pmh-handler): strip XML-illegal control chars from marshalled output

### DIFF
--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/JaxbXmlSerializer.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/JaxbXmlSerializer.java
@@ -4,7 +4,6 @@ import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import java.io.StringWriter;
-import javax.xml.stream.XMLStreamException;
 import org.openarchives.oai.pmh.v2.OAIPMHtype;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,16 +21,15 @@ public class JaxbXmlSerializer implements XmlSerializer {
   public String serialize(JAXBElement<OAIPMHtype> objectToSerialize) {
     try {
       return marshal(objectToSerialize);
-    } catch (JAXBException | XMLStreamException e) {
+    } catch (JAXBException e) {
       LOGGER.error("Failed to serialize object to xml!", e);
       throw new XmlSerializationException("Invalid xml content or streaming issue encountered!", e);
     }
   }
 
-  private String marshal(final JAXBElement<OAIPMHtype> objectToSerialize)
-      throws JAXBException, XMLStreamException {
+  private String marshal(final JAXBElement<OAIPMHtype> objectToSerialize) throws JAXBException {
     var writer = new StringWriter();
-    marshaller.marshal(objectToSerialize, writer);
+    marshaller.marshal(objectToSerialize, new XmlCharFilteringWriter(writer));
     return writer.toString();
   }
 }

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/XmlCharFilteringWriter.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/XmlCharFilteringWriter.java
@@ -30,7 +30,8 @@ final class XmlCharFilteringWriter extends FilterWriter {
     for (var position = 0; position < length; position++) {
       var character = buffer[offset + position];
       if (isValidXmlChar(character)) {
-        sanitized[index++] = character;
+        sanitized[index] = character;
+        index++;
       }
     }
     super.write(sanitized, 0, index);

--- a/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/XmlCharFilteringWriter.java
+++ b/oai-pmh-handler/src/main/java/no/sikt/nva/oai/pmh/handler/XmlCharFilteringWriter.java
@@ -1,0 +1,50 @@
+package no.sikt.nva.oai.pmh.handler;
+
+import java.io.FilterWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+final class XmlCharFilteringWriter extends FilterWriter {
+
+  private static final int TAB = 0x9;
+  private static final int LINE_FEED = 0xA;
+  private static final int CARRIAGE_RETURN = 0xD;
+  private static final int FIRST_PRINTABLE = 0x20;
+  private static final int LAST_VALID_BMP = 0xFFFD;
+
+  XmlCharFilteringWriter(Writer delegate) {
+    super(delegate);
+  }
+
+  @Override
+  public void write(int character) throws IOException {
+    if (isValidXmlChar(character)) {
+      super.write(character);
+    }
+  }
+
+  @Override
+  public void write(char[] buffer, int offset, int length) throws IOException {
+    var sanitized = new char[length];
+    var index = 0;
+    for (var position = 0; position < length; position++) {
+      var character = buffer[offset + position];
+      if (isValidXmlChar(character)) {
+        sanitized[index++] = character;
+      }
+    }
+    super.write(sanitized, 0, index);
+  }
+
+  @Override
+  public void write(String value, int offset, int length) throws IOException {
+    write(value.toCharArray(), offset, length);
+  }
+
+  private static boolean isValidXmlChar(int character) {
+    return character == TAB
+        || character == LINE_FEED
+        || character == CARRIAGE_RETURN
+        || (character >= FIRST_PRINTABLE && character <= LAST_VALID_BMP);
+  }
+}

--- a/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandlerTest.java
+++ b/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/OaiPmhHandlerTest.java
@@ -785,6 +785,31 @@ class OaiPmhHandlerTest {
   }
 
   @Test
+  void shouldStripXmlIllegalControlCharactersFromContributorName()
+      throws IOException, JAXBException {
+    var pollutedContributorName = "Per Nordmann";
+    var sanitizedContributorName = "Per Nordmann";
+    var hit =
+        ResourceDocumentFactory.builder(
+                RESOURCE_ID, RESOURCE_TITLE, PUBLICATION_YEAR, PUBLICATION_MONTH, PUBLICATION_DAY)
+            .withTopLevelOrganization(NTNU_ID, NTNU_LABELS)
+            .withContributor(pollutedContributorName, null)
+            .academicArticle(new SerialChannelBuilder("Journal", JOURNAL_NAME))
+            .apply()
+            .build();
+    var inputStream = hitAndRequest(wrapHits(hit));
+
+    var gatewayResponse = invokeHandler(inputStream);
+
+    assertThat(gatewayResponse.getStatusCode(), is(equalTo(HTTP_OK)));
+    assertThat(gatewayResponse.getBody(), not(containsString("")));
+
+    var response = Input.fromString(gatewayResponse.getBody()).build();
+    var contributors = extractValuesFromDcElements("contributor", response);
+    assertThat(contributors, hasItem(sanitizedContributorName));
+  }
+
+  @Test
   void shouldMapAbstractToRecordMetadataDcDescription() throws IOException, JAXBException {
     var inputStream = defaultHitAndRequest();
 

--- a/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/XmlCharFilteringWriterTest.java
+++ b/oai-pmh-handler/src/test/java/no/sikt/nva/oai/pmh/handler/XmlCharFilteringWriterTest.java
@@ -1,0 +1,53 @@
+package no.sikt.nva.oai.pmh.handler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+
+class XmlCharFilteringWriterTest {
+
+  @Test
+  void shouldDropIllegalControlCharacterWhenWritingSingleChar() throws IOException {
+    var sink = new StringWriter();
+    try (var writer = new XmlCharFilteringWriter(sink)) {
+      writer.write('a');
+      writer.write(0x01);
+      writer.write('b');
+    }
+    assertThat(sink.toString(), is(equalTo("ab")));
+  }
+
+  @Test
+  void shouldDropIllegalControlCharactersWhenWritingCharArraySlice() throws IOException {
+    var sink = new StringWriter();
+    var buffer = ("xNat" + (char) 0x01 + "alie" + (char) 0x0B + "y").toCharArray();
+    try (var writer = new XmlCharFilteringWriter(sink)) {
+      writer.write(buffer, 1, buffer.length - 2);
+    }
+    assertThat(sink.toString(), is(equalTo("Natalie")));
+  }
+
+  @Test
+  void shouldDropIllegalControlCharactersWhenWritingStringSlice() throws IOException {
+    var sink = new StringWriter();
+    var input = "ignoreP" + (char) 0x01 + "er Nor" + (char) 0x01 + "dmannignore";
+    try (var writer = new XmlCharFilteringWriter(sink)) {
+      writer.write(input, "ignore".length(), input.length() - 2 * "ignore".length());
+    }
+    assertThat(sink.toString(), is(equalTo("Per Nordmann")));
+  }
+
+  @Test
+  void shouldPreserveValidWhitespaceAndPrintableCharacters() throws IOException {
+    var sink = new StringWriter();
+    var input = "tab\there\nline\rcr ascii";
+    try (var writer = new XmlCharFilteringWriter(sink)) {
+      writer.write(input, 0, input.length());
+    }
+    assertThat(sink.toString(), is(equalTo(input)));
+  }
+}

--- a/oai-pmh-handler/src/test/resources/firstPageHits.json
+++ b/oai-pmh-handler/src/test/resources/firstPageHits.json
@@ -54,7 +54,7 @@
           },
           "identity": {
             "verificationStatus": "Verified",
-            "name": "P\u0001er Nor\u0001dmann",
+            "name": "Saverio Messineo",
             "id": "https://api.unittests.nva.aws.unit.no/cristin/person/35885",
             "type": "Identity"
           },
@@ -130,7 +130,7 @@
           },
           "identity": {
             "verificationStatus": "Verified",
-            "name": "P\u0001er Nor\u0001dmann",
+            "name": "Saverio Messineo",
             "id": "https://api.unittests.nva.aws.unit.no/cristin/person/35885",
             "type": "Identity"
           },
@@ -293,7 +293,7 @@
         "contributorCristinIds": [
           {
             "verificationStatus": "Verified",
-            "name": "P\u0001er Nor\u0001dmann",
+            "name": "Saverio Messineo",
             "id": "https://api.unittests.nva.aws.unit.no/cristin/person/35885",
             "type": "Identity"
           },

--- a/oai-pmh-handler/src/test/resources/firstPageHits.json
+++ b/oai-pmh-handler/src/test/resources/firstPageHits.json
@@ -54,7 +54,7 @@
           },
           "identity": {
             "verificationStatus": "Verified",
-            "name": "Saverio Messineo",
+            "name": "P\u0001er Nor\u0001dmann",
             "id": "https://api.unittests.nva.aws.unit.no/cristin/person/35885",
             "type": "Identity"
           },
@@ -130,7 +130,7 @@
           },
           "identity": {
             "verificationStatus": "Verified",
-            "name": "Saverio Messineo",
+            "name": "P\u0001er Nor\u0001dmann",
             "id": "https://api.unittests.nva.aws.unit.no/cristin/person/35885",
             "type": "Identity"
           },
@@ -293,7 +293,7 @@
         "contributorCristinIds": [
           {
             "verificationStatus": "Verified",
-            "name": "Saverio Messineo",
+            "name": "P\u0001er Nor\u0001dmann",
             "id": "https://api.unittests.nva.aws.unit.no/cristin/person/35885",
             "type": "Identity"
           },


### PR DESCRIPTION
## Summary
External harvesters (Oria) saw HTTP 200 responses from OAI-PMH ListRecords that failed XML parsing, because contributor names, organization labels, publisher/journal names and identifiers were emitted with raw `\x01..\x1F` control bytes that XML 1.0 forbids. Sanitization is now done at the marshaller's writer boundary so every value flowing through JAXB is filtered, not a hand-curated set of fields.

- new `XmlCharFilteringWriter` wraps the `StringWriter` passed to the marshaller and drops characters outside the XML 1.0 `Char` whitelist (TAB, LF, CR, `0x20–0xFFFD`)
- `JaxbXmlSerializer.marshal` plugs the filter in, no other call sites change
- regression coverage: `firstPageHits.json` now carries `` bytes in a contributor name, so the existing list-records tests would fail XPath parsing without the fix
- unit tests cover all three `Writer.write` overloads

https://sikt.atlassian.net/browse/NP-51201