### PR TITLE
feat(search): add Link and X-Total-Count pagination headers for bibtex/csv

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -65,10 +65,18 @@ paths:
       responses:
         "200":
           description: "OK"
+          headers:
+            Link:
+              $ref: "#/components/headers/LinkHeader"
+            X-Total-Count:
+              $ref: "#/components/headers/XTotalCountHeader"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/PagedImportCandidateSearchResponse"
+            text/csv:
+              schema:
+                type: string
         "400":
           description: Bad Request
           content:
@@ -148,10 +156,18 @@ paths:
       responses:
         "200":
           description: "OK"
+          headers:
+            Link:
+              $ref: "#/components/headers/LinkHeader"
+            X-Total-Count:
+              $ref: "#/components/headers/XTotalCountHeader"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/TicketSearchResponse"
+            text/csv:
+              schema:
+                type: string
         "400":
           description: Bad Request
           content:
@@ -303,10 +319,21 @@ paths:
       responses:
         "200":
           description: "OK"
+          headers:
+            Link:
+              $ref: "#/components/headers/LinkHeader"
+            X-Total-Count:
+              $ref: "#/components/headers/XTotalCountHeader"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/PagedPublicationFullSearchResponse"
+            text/csv:
+              schema:
+                type: string
+            text/x-bibtex:
+              schema:
+                type: string
         "400":
           description: Bad Request
           content:
@@ -627,10 +654,21 @@ paths:
       responses:
         "200":
           description: "OK"
+          headers:
+            Link:
+              $ref: "#/components/headers/LinkHeader"
+            X-Total-Count:
+              $ref: "#/components/headers/XTotalCountHeader"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/PagedPublicationSearchResponse"
+            text/csv:
+              schema:
+                type: string
+            text/x-bibtex:
+              schema:
+                type: string
         "400":
           description: Bad Request
           content:
@@ -802,6 +840,19 @@ paths:
                 $ref: "#/components/schemas/Problem"
 
 components:
+  headers:
+    LinkHeader:
+      description: |
+        RFC 8288 pagination links with rel=first/prev/next/last.
+        Present on text/csv and text/x-bibtex responses when the result spans multiple pages.
+      schema:
+        type: string
+    XTotalCountHeader:
+      description: |
+        Total number of matching results.
+        Present on text/csv and text/x-bibtex responses.
+      schema:
+        type: integer
   parameters:
     abstractParam:
       name: abstract

--- a/search-commons/src/main/java/no/unit/nva/constants/Words.java
+++ b/search-commons/src/main/java/no/unit/nva/constants/Words.java
@@ -129,6 +129,7 @@ public final class Words {
   public static final String SEARCH_INFRASTRUCTURE_CREDENTIALS = "SearchInfrastructureCredentials";
   public static final String SERIES = "series";
   public static final String SERIES_AS_TYPE = "Series";
+  public static final String SIZE = "size";
   public static final String SLASH = "/";
   public static final String SORT_LAST = "_last";
   public static final String SOURCE = "source";

--- a/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
@@ -9,6 +9,8 @@ import static nva.commons.core.paths.UriWrapper.fromUri;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -30,6 +32,15 @@ import nva.commons.apigateway.MediaType;
  *     define the parameters that can be used in the query.
  */
 public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
+  private static final String HEADER_LINK = "Link";
+  private static final String HEADER_X_TOTAL_COUNT = "X-Total-Count";
+  private static final String REL_FIRST = "first";
+  private static final String REL_PREV = "prev";
+  private static final String REL_NEXT = "next";
+  private static final String REL_LAST = "last";
+  private static final String LINK_VALUE_FORMAT = "<%s>; rel=\"%s\"";
+  private static final String LINK_HEADER_SEPARATOR = ", ";
+
   private final SwsResponse response;
   private final MediaType mediaType;
   private final URI source;
@@ -110,6 +121,60 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
 
   public String toBibTexText() {
     return ResourceBibTexTransformer.transform(response.getSearchHits());
+  }
+
+  public Map<String, String> paginationHeaders() {
+    if (!isPlainTextMediaType()) {
+      return Map.of();
+    }
+    var total = response.getTotalSize();
+    var headers = new LinkedHashMap<String, String>();
+    headers.put(HEADER_X_TOTAL_COUNT, String.valueOf(total));
+    var linkValue = buildLinkHeaderValue(total);
+    if (hasContent(linkValue)) {
+      headers.put(HEADER_LINK, linkValue);
+    }
+    return headers;
+  }
+
+  private boolean isPlainTextMediaType() {
+    return nonNull(mediaType) && (CSV_UTF_8.matches(mediaType) || BIBTEX_UTF_8.matches(mediaType));
+  }
+
+  private String buildLinkHeaderValue(int total) {
+    if (!isPaginatable(total)) {
+      return "";
+    }
+    var current = nonNull(offset) ? offset : 0;
+    var links = new ArrayList<String>();
+    links.add(formatLink(uriWithFrom(0), REL_FIRST));
+    if (current > 0) {
+      links.add(formatLink(uriWithFrom(Math.max(0, current - size)), REL_PREV));
+    }
+    if (current + size < total) {
+      links.add(formatLink(uriWithFrom(current + size), REL_NEXT));
+    }
+    links.add(formatLink(uriWithFrom(lastPageOffset(total)), REL_LAST));
+    return String.join(LINK_HEADER_SEPARATOR, links);
+  }
+
+  private boolean isPaginatable(int total) {
+    return total > 0 && nonNull(size) && size > 0 && total > size;
+  }
+
+  private int lastPageOffset(int total) {
+    return (total - 1) / size * size;
+  }
+
+  private URI uriWithFrom(int newFrom) {
+    var params = nonNull(queryKeys) ? queryKeys.asMap() : new LinkedHashMap<String, String>();
+    params.put(Words.FROM, String.valueOf(newFrom));
+    params.put(Words.SIZE, String.valueOf(size));
+    return fromUri(source).addQueryParameters(params).getUri();
+  }
+
+  private static String formatLink(URI uri, String rel) {
+    return LINK_VALUE_FORMAT.formatted(uri, rel);
   }
 
   private Map<String, String> getRequestParameter() {

--- a/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
@@ -6,6 +6,7 @@ import static no.unit.nva.constants.Words.COMMA;
 import static no.unit.nva.search.common.constant.Functions.hasContent;
 import static nva.commons.apigateway.MediaType.CSV_UTF_8;
 import static nva.commons.core.paths.UriWrapper.fromUri;
+import static org.apache.hc.core5.http.HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
@@ -35,8 +36,6 @@ import nva.commons.apigateway.MediaType;
 public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
   private static final String HEADER_LINK = "Link";
   private static final String HEADER_X_TOTAL_COUNT = "X-Total-Count";
-  private static final String HEADER_ACCESS_CONTROL_EXPOSE_HEADERS =
-      "Access-Control-Expose-Headers";
   private static final String EXPOSED_PAGINATION_HEADERS =
       String.join(", ", HEADER_LINK, HEADER_X_TOTAL_COUNT);
   private static final String REL_FIRST = "first";
@@ -135,7 +134,7 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
     var total = response.getTotalSize();
     var headers = new LinkedHashMap<String, String>();
     headers.put(HEADER_X_TOTAL_COUNT, String.valueOf(total));
-    headers.put(HEADER_ACCESS_CONTROL_EXPOSE_HEADERS, EXPOSED_PAGINATION_HEADERS);
+    headers.put(ACCESS_CONTROL_EXPOSE_HEADERS, EXPOSED_PAGINATION_HEADERS);
     buildLinkHeaderValue(total).ifPresent(value -> headers.put(HEADER_LINK, value));
     return headers;
   }

--- a/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
@@ -37,7 +37,8 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
   private static final String HEADER_X_TOTAL_COUNT = "X-Total-Count";
   private static final String HEADER_ACCESS_CONTROL_EXPOSE_HEADERS =
       "Access-Control-Expose-Headers";
-  private static final String EXPOSED_PAGINATION_HEADERS = "Link, X-Total-Count";
+  private static final String EXPOSED_PAGINATION_HEADERS =
+      String.join(", ", HEADER_LINK, HEADER_X_TOTAL_COUNT);
   private static final String REL_FIRST = "first";
   private static final String REL_PREV = "prev";
   private static final String REL_NEXT = "next";

--- a/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.constants.Words;
@@ -34,6 +35,9 @@ import nva.commons.apigateway.MediaType;
 public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
   private static final String HEADER_LINK = "Link";
   private static final String HEADER_X_TOTAL_COUNT = "X-Total-Count";
+  private static final String HEADER_ACCESS_CONTROL_EXPOSE_HEADERS =
+      "Access-Control-Expose-Headers";
+  private static final String EXPOSED_PAGINATION_HEADERS = "Link, X-Total-Count";
   private static final String REL_FIRST = "first";
   private static final String REL_PREV = "prev";
   private static final String REL_NEXT = "next";
@@ -130,10 +134,8 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
     var total = response.getTotalSize();
     var headers = new LinkedHashMap<String, String>();
     headers.put(HEADER_X_TOTAL_COUNT, String.valueOf(total));
-    var linkValue = buildLinkHeaderValue(total);
-    if (hasContent(linkValue)) {
-      headers.put(HEADER_LINK, linkValue);
-    }
+    headers.put(HEADER_ACCESS_CONTROL_EXPOSE_HEADERS, EXPOSED_PAGINATION_HEADERS);
+    buildLinkHeaderValue(total).ifPresent(value -> headers.put(HEADER_LINK, value));
     return headers;
   }
 
@@ -141,9 +143,9 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
     return nonNull(mediaType) && (CSV_UTF_8.matches(mediaType) || BIBTEX_UTF_8.matches(mediaType));
   }
 
-  private String buildLinkHeaderValue(int total) {
+  private Optional<String> buildLinkHeaderValue(int total) {
     if (!isPaginatable(total)) {
-      return "";
+      return Optional.empty();
     }
     var current = nonNull(offset) ? offset : 0;
     var links = new ArrayList<String>();
@@ -155,7 +157,7 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
       links.add(formatLink(uriWithFrom(current + size), REL_NEXT));
     }
     links.add(formatLink(uriWithFrom(lastPageOffset(total)), REL_LAST));
-    return String.join(LINK_HEADER_SEPARATOR, links);
+    return Optional.of(String.join(LINK_HEADER_SEPARATOR, links));
   }
 
   private boolean isPaginatable(int total) {
@@ -167,7 +169,7 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
   }
 
   private URI uriWithFrom(int newFrom) {
-    var params = nonNull(queryKeys) ? queryKeys.asMap() : new LinkedHashMap<String, String>();
+    var params = getRequestParameter();
     params.put(Words.FROM, String.valueOf(newFrom));
     params.put(Words.SIZE, String.valueOf(size));
     return fromUri(source).addQueryParameters(params).getUri();
@@ -178,7 +180,7 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
   }
 
   private Map<String, String> getRequestParameter() {
-    return queryKeys.asMap();
+    return nonNull(queryKeys) ? queryKeys.asMap() : new LinkedHashMap<>();
   }
 
   private URI nextResultsBySortKey(Map<String, String> requestParameter, URI gatewayUri) {

--- a/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
@@ -123,28 +123,28 @@ class HttpResponseFormatterPaginationHeadersTest {
   void shouldPointLastAtFinalPageOffset() {
     var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 95).paginationHeaders();
 
-    assertThat(headers.get(LINK), containsString("from=90"));
+    assertThat(headers.get(LINK), containsString("from=90&size=10>; rel=\"last\""));
   }
 
   @Test
   void shouldPointPrevAtPreviousPageOffset() {
     var headers = formatterFor(BIBTEX_UTF_8, 30, 10, 100).paginationHeaders();
 
-    assertThat(headers.get(LINK), containsString("from=20"));
+    assertThat(headers.get(LINK), containsString("from=20&size=10>; rel=\"prev\""));
   }
 
   @Test
   void shouldPointNextAtNextPageOffset() {
     var headers = formatterFor(BIBTEX_UTF_8, 30, 10, 100).paginationHeaders();
 
-    assertThat(headers.get(LINK), containsString("from=40"));
+    assertThat(headers.get(LINK), containsString("from=40&size=10>; rel=\"next\""));
   }
 
   @Test
   void shouldClampPrevAtZeroWhenOffsetSmallerThanSize() {
     var headers = formatterFor(BIBTEX_UTF_8, 5, 10, 100).paginationHeaders();
 
-    assertThat(headers.get(LINK), containsString("from=0"));
+    assertThat(headers.get(LINK), containsString("from=0&size=10>; rel=\"prev\""));
   }
 
   @Test

--- a/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
@@ -1,0 +1,180 @@
+package no.unit.nva.search.common.records;
+
+import static no.unit.nva.constants.Defaults.BIBTEX_UTF_8;
+import static nva.commons.apigateway.MediaType.CSV_UTF_8;
+import static nva.commons.apigateway.MediaType.JSON_UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+
+import java.net.URI;
+import java.util.Map;
+import no.unit.nva.search.common.records.SwsResponse.HitsInfo;
+import no.unit.nva.search.common.records.SwsResponse.HitsInfo.TotalInfo;
+import nva.commons.apigateway.MediaType;
+import nva.commons.apigateway.MediaTypes;
+import org.junit.jupiter.api.Test;
+
+class HttpResponseFormatterPaginationHeadersTest {
+
+  private static final URI SOURCE = URI.create("https://api.example.com/search/resources");
+  private static final String LINK = "Link";
+  private static final String X_TOTAL_COUNT = "X-Total-Count";
+
+  @Test
+  void shouldReturnEmptyHeadersWhenMediaTypeIsJson() {
+    var headers = formatterFor(JSON_UTF_8, 0, 10, 100).paginationHeaders();
+
+    assertThat(headers, anEmptyMap());
+  }
+
+  @Test
+  void shouldReturnEmptyHeadersWhenMediaTypeIsJsonLd() {
+    var headers = formatterFor(MediaTypes.APPLICATION_JSON_LD, 0, 10, 100).paginationHeaders();
+
+    assertThat(headers, anEmptyMap());
+  }
+
+  @Test
+  void shouldEmitTotalCountHeaderForCsv() {
+    var headers = formatterFor(CSV_UTF_8, 0, 10, 100).paginationHeaders();
+
+    assertThat(headers, hasEntry(X_TOTAL_COUNT, "100"));
+  }
+
+  @Test
+  void shouldEmitTotalCountHeaderForBibtex() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+
+    assertThat(headers, hasEntry(X_TOTAL_COUNT, "100"));
+  }
+
+  @Test
+  void shouldEmitFirstNextAndLastButNotPrevOnFirstPage() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+
+    var link = headers.get(LINK);
+    assertThat(
+        link,
+        allOf(
+            containsString("rel=\"first\""),
+            containsString("rel=\"next\""),
+            containsString("rel=\"last\""),
+            not(containsString("rel=\"prev\""))));
+  }
+
+  @Test
+  void shouldEmitAllRelsOnMiddlePage() {
+    var headers = formatterFor(BIBTEX_UTF_8, 20, 10, 100).paginationHeaders();
+
+    var link = headers.get(LINK);
+    assertThat(
+        link,
+        allOf(
+            containsString("rel=\"first\""),
+            containsString("rel=\"prev\""),
+            containsString("rel=\"next\""),
+            containsString("rel=\"last\"")));
+  }
+
+  @Test
+  void shouldEmitFirstPrevAndLastButNotNextOnLastPage() {
+    var headers = formatterFor(BIBTEX_UTF_8, 90, 10, 100).paginationHeaders();
+
+    var link = headers.get(LINK);
+    assertThat(
+        link,
+        allOf(
+            containsString("rel=\"first\""),
+            containsString("rel=\"prev\""),
+            containsString("rel=\"last\""),
+            not(containsString("rel=\"next\""))));
+  }
+
+  @Test
+  void shouldPointLastAtFinalPageOffset() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 95).paginationHeaders();
+
+    assertThat(headers.get(LINK), containsString("from=90"));
+  }
+
+  @Test
+  void shouldPointPrevAtPreviousPageOffset() {
+    var headers = formatterFor(BIBTEX_UTF_8, 30, 10, 100).paginationHeaders();
+
+    assertThat(headers.get(LINK), containsString("from=20"));
+  }
+
+  @Test
+  void shouldPointNextAtNextPageOffset() {
+    var headers = formatterFor(BIBTEX_UTF_8, 30, 10, 100).paginationHeaders();
+
+    assertThat(headers.get(LINK), containsString("from=40"));
+  }
+
+  @Test
+  void shouldClampPrevAtZeroWhenOffsetSmallerThanSize() {
+    var headers = formatterFor(BIBTEX_UTF_8, 5, 10, 100).paginationHeaders();
+
+    assertThat(headers.get(LINK), containsString("from=0"));
+  }
+
+  @Test
+  void shouldOmitLinkHeaderWhenSinglePage() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 100, 25).paginationHeaders();
+
+    assertThat(headers, hasEntry(X_TOTAL_COUNT, "25"));
+    assertThat(headers, not(hasKey(LINK)));
+  }
+
+  @Test
+  void shouldOmitLinkHeaderWhenTotalIsZero() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 0).paginationHeaders();
+
+    assertThat(headers, hasEntry(X_TOTAL_COUNT, "0"));
+    assertThat(headers, not(hasKey(LINK)));
+  }
+
+  @Test
+  void shouldOmitLinkHeaderWhenSizeIsZero() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 0, 100).paginationHeaders();
+
+    assertThat(headers, hasEntry(X_TOTAL_COUNT, "100"));
+    assertThat(headers, not(hasKey(LINK)));
+  }
+
+  @Test
+  void shouldUseSourceUriAsBaseForLinks() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+
+    assertThat(headers.get(LINK), containsString(SOURCE.toString()));
+  }
+
+  @Test
+  void shouldIncludeSizeInLinkUrls() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+
+    assertThat(headers.get(LINK), containsString("size=10"));
+  }
+
+  @Test
+  void shouldFormatLinkValueWithRfc8288Syntax() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+    var link = headers.get(LINK);
+
+    assertThat(link, containsString("<"));
+    assertThat(link, containsString(">; rel=\""));
+  }
+
+  private static HttpResponseFormatter<?> formatterFor(
+      MediaType mediaType, int offset, int size, int totalHits) {
+    var hitsInfo = new HitsInfo(new TotalInfo(totalHits, "eq"), 0.0, java.util.List.of());
+    var swsResponse = new SwsResponse(0, false, null, hitsInfo, null, null);
+    return new HttpResponseFormatter<>(
+        swsResponse, mediaType, SOURCE, offset, size, Map.of(), null);
+  }
+}

--- a/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import no.unit.nva.search.common.records.SwsResponse.HitsInfo;
 import no.unit.nva.search.common.records.SwsResponse.HitsInfo.TotalInfo;
@@ -24,6 +25,8 @@ class HttpResponseFormatterPaginationHeadersTest {
   private static final URI SOURCE = URI.create("https://api.example.com/search/resources");
   private static final String LINK = "Link";
   private static final String X_TOTAL_COUNT = "X-Total-Count";
+  private static final String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
+  private static final String EXPECTED_EXPOSED_HEADERS = "Link, X-Total-Count";
 
   @Test
   void shouldReturnEmptyHeadersWhenMediaTypeIsJson() {
@@ -37,6 +40,27 @@ class HttpResponseFormatterPaginationHeadersTest {
     var headers = formatterFor(MediaTypes.APPLICATION_JSON_LD, 0, 10, 100).paginationHeaders();
 
     assertThat(headers, anEmptyMap());
+  }
+
+  @Test
+  void shouldEmitExposeHeadersForCsv() {
+    var headers = formatterFor(CSV_UTF_8, 0, 10, 100).paginationHeaders();
+
+    assertThat(headers, hasEntry(ACCESS_CONTROL_EXPOSE_HEADERS, EXPECTED_EXPOSED_HEADERS));
+  }
+
+  @Test
+  void shouldEmitExposeHeadersForBibtex() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+
+    assertThat(headers, hasEntry(ACCESS_CONTROL_EXPOSE_HEADERS, EXPECTED_EXPOSED_HEADERS));
+  }
+
+  @Test
+  void shouldEmitExposeHeadersEvenWhenSinglePage() {
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 100, 25).paginationHeaders();
+
+    assertThat(headers, hasEntry(ACCESS_CONTROL_EXPOSE_HEADERS, EXPECTED_EXPOSED_HEADERS));
   }
 
   @Test
@@ -172,7 +196,7 @@ class HttpResponseFormatterPaginationHeadersTest {
 
   private static HttpResponseFormatter<?> formatterFor(
       MediaType mediaType, int offset, int size, int totalHits) {
-    var hitsInfo = new HitsInfo(new TotalInfo(totalHits, "eq"), 0.0, java.util.List.of());
+    var hitsInfo = new HitsInfo(new TotalInfo(totalHits, "eq"), 0.0, List.of());
     var swsResponse = new SwsResponse(0, false, null, hitsInfo, null, null);
     return new HttpResponseFormatter<>(
         swsResponse, mediaType, SOURCE, offset, size, Map.of(), null);

--- a/search-handlers/src/main/java/no/unit/nva/search/SearchImportCandidateAuthHandler.java
+++ b/search-handlers/src/main/java/no/unit/nva/search/SearchImportCandidateAuthHandler.java
@@ -44,13 +44,17 @@ public class SearchImportCandidateAuthHandler extends ApiGatewayHandler<Void, St
   @Override
   protected String processInput(Void input, RequestInfo requestInfo, Context context)
       throws BadRequestException {
-    return ImportCandidateSearchQuery.builder()
-        .fromRequestInfo(requestInfo)
-        .withRequiredParameters(FROM, SIZE, AGGREGATION)
-        .validate()
-        .build()
-        .doSearch(opensearchClient, Words.IMPORT_CANDIDATES_INDEX)
-        .toString();
+    var formatter =
+        ImportCandidateSearchQuery.builder()
+            .fromRequestInfo(requestInfo)
+            .withRequiredParameters(FROM, SIZE, AGGREGATION)
+            .validate()
+            .build()
+            .doSearch(opensearchClient, Words.IMPORT_CANDIDATES_INDEX);
+
+    addAdditionalHeaders(formatter::paginationHeaders);
+
+    return formatter.toString();
   }
 
   @Override

--- a/search-handlers/src/main/java/no/unit/nva/search/SearchResourceAuthHandler.java
+++ b/search-handlers/src/main/java/no/unit/nva/search/SearchResourceAuthHandler.java
@@ -63,18 +63,22 @@ public class SearchResourceAuthHandler extends ApiGatewayHandler<Void, String> {
       throws BadRequestException, UnauthorizedException {
     var version = ContentTypeUtils.extractVersionFromRequestInfo(requestInfo);
 
-    return ResourceSearchQuery.builder()
-        .fromRequestInfo(requestInfo)
-        .withRequiredParameters(FROM, SIZE, AGGREGATION, SORT)
-        .withAlwaysExcludedFields(getExcludedFields(version))
-        .validate()
-        .build()
-        .withFilter()
-        .customerCurationInstitutions(requestInfo)
-        .apply()
-        .doSearch(opensearchClient, Words.RESOURCES)
-        .withMutators(getMutator(version))
-        .toString();
+    var formatter =
+        ResourceSearchQuery.builder()
+            .fromRequestInfo(requestInfo)
+            .withRequiredParameters(FROM, SIZE, AGGREGATION, SORT)
+            .withAlwaysExcludedFields(getExcludedFields(version))
+            .validate()
+            .build()
+            .withFilter()
+            .customerCurationInstitutions(requestInfo)
+            .apply()
+            .doSearch(opensearchClient, Words.RESOURCES)
+            .withMutators(getMutator(version));
+
+    addAdditionalHeaders(formatter::paginationHeaders);
+
+    return formatter.toString();
   }
 
   @Override

--- a/search-handlers/src/main/java/no/unit/nva/search/SearchResourceHandler.java
+++ b/search-handlers/src/main/java/no/unit/nva/search/SearchResourceHandler.java
@@ -12,6 +12,7 @@ import static no.unit.nva.search.resource.ResourceParameter.SORT;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import no.unit.nva.constants.Words;
@@ -71,20 +72,29 @@ public class SearchResourceHandler extends ApiGatewayHandler<Void, String> {
         requestInfo.getQueryParameters());
     var version = ContentTypeUtils.extractVersionFromRequestInfo(requestInfo);
 
-    addAdditionalHeaders(() -> Map.of(HttpHeaders.VARY, HttpHeaders.ACCEPT));
+    var formatter =
+        ResourceSearchQuery.builder()
+            .fromRequestInfo(requestInfo)
+            .withRequiredParameters(FROM, SIZE, AGGREGATION, SORT)
+            .withAlwaysIncludedFields(getIncludedFields(version))
+            .validate()
+            .build()
+            .withFilter()
+            .requiredStatus(PUBLISHED, PUBLISHED_METADATA)
+            .apply()
+            .doSearch(opensearchClient, Words.RESOURCES)
+            .withMutators(getMutator(version));
 
-    return ResourceSearchQuery.builder()
-        .fromRequestInfo(requestInfo)
-        .withRequiredParameters(FROM, SIZE, AGGREGATION, SORT)
-        .withAlwaysIncludedFields(getIncludedFields(version))
-        .validate()
-        .build()
-        .withFilter()
-        .requiredStatus(PUBLISHED, PUBLISHED_METADATA)
-        .apply()
-        .doSearch(opensearchClient, Words.RESOURCES)
-        .withMutators(getMutator(version))
-        .toString();
+    addAdditionalHeaders(() -> responseHeaders(formatter.paginationHeaders()));
+
+    return formatter.toString();
+  }
+
+  private Map<String, String> responseHeaders(Map<String, String> paginationHeaders) {
+    var headers = new LinkedHashMap<String, String>();
+    headers.put(HttpHeaders.VARY, HttpHeaders.ACCEPT);
+    headers.putAll(paginationHeaders);
+    return headers;
   }
 
   private List<String> getIncludedFields(String version) {

--- a/search-handlers/src/main/java/no/unit/nva/search/SearchTicketAuthHandler.java
+++ b/search-handlers/src/main/java/no/unit/nva/search/SearchTicketAuthHandler.java
@@ -55,14 +55,18 @@ public class SearchTicketAuthHandler extends ApiGatewayHandler<Void, String> {
   protected String processInput(Void input, RequestInfo requestInfo, Context context)
       throws BadRequestException, UnauthorizedException {
 
-    return TicketSearchQuery.builder()
-        .fromRequestInfo(requestInfo)
-        .withRequiredParameters(FROM, SIZE, AGGREGATION)
-        .build()
-        .withFilter()
-        .fromRequestInfo(requestInfo)
-        .doSearch(opensearchClient, Words.TICKETS)
-        .toString();
+    var formatter =
+        TicketSearchQuery.builder()
+            .fromRequestInfo(requestInfo)
+            .withRequiredParameters(FROM, SIZE, AGGREGATION)
+            .build()
+            .withFilter()
+            .fromRequestInfo(requestInfo)
+            .doSearch(opensearchClient, Words.TICKETS);
+
+    addAdditionalHeaders(formatter::paginationHeaders);
+
+    return formatter.toString();
   }
 
   @Override

--- a/search-handlers/src/test/java/no/unit/nva/search/SearchResource20241201HandlerTest.java
+++ b/search-handlers/src/test/java/no/unit/nva/search/SearchResource20241201HandlerTest.java
@@ -9,6 +9,10 @@ import static nva.commons.core.ioutils.IoUtils.stringFromResources;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -17,12 +21,15 @@ import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import no.unit.nva.search.common.records.SwsResponse;
 import no.unit.nva.search.resource.ResourceClient;
@@ -96,11 +103,71 @@ class SearchResource20241201HandlerTest {
     assertThat(gatewayResponse.statusCode(), is(equalTo(HTTP_OK)));
   }
 
+  @Test
+  void shouldEmitPaginationHeadersWhenRequestingBibtex() throws IOException {
+    prepareRestHighLevelClientOkResponse();
+    handler.handleRequest(getBibtexInputStream(), outputStream, contextMock);
+
+    var headers = rawHeaders(outputStream);
+    assertThat(headers, hasEntry("X-Total-Count", "2"));
+    assertThat(headers, hasKey("Link"));
+    assertThat(headers.get("Link"), containsString("rel=\"first\""));
+    assertThat(headers.get("Link"), containsString("rel=\"next\""));
+    assertThat(headers.get("Link"), containsString("rel=\"last\""));
+  }
+
+  @Test
+  void shouldEmitTotalCountButNoLinkOnSinglePageBibtexResponse() throws IOException {
+    prepareRestHighLevelClientOkResponse();
+    handler.handleRequest(getBibtexInputStreamLargePageSize(), outputStream, contextMock);
+
+    var headers = rawHeaders(outputStream);
+    assertThat(headers, hasEntry("X-Total-Count", "2"));
+    assertThat(headers, not(hasKey("Link")));
+  }
+
+  @Test
+  void shouldNotEmitPaginationHeadersForJsonResponses() throws IOException {
+    prepareRestHighLevelClientOkResponse();
+    handler.handleRequest(getInputStream(), outputStream, contextMock);
+
+    var headers = rawHeaders(outputStream);
+    assertThat(headers, not(hasKey("X-Total-Count")));
+    assertThat(headers, not(hasKey("Link")));
+  }
+
   private InputStream getInputStream() throws JsonProcessingException {
     return new HandlerRequestBuilder<Void>(objectMapperWithEmpty)
         .withQueryParameters(Map.of(SEARCH_ALL.name(), SAMPLE_SEARCH_TERM))
         .withRequestContext(getRequestContext())
         .build();
+  }
+
+  private InputStream getBibtexInputStream() throws JsonProcessingException {
+    return new HandlerRequestBuilder<Void>(objectMapperWithEmpty)
+        .withMultiValueQueryParameters(
+            Map.of(SEARCH_ALL.name(), List.of(SAMPLE_SEARCH_TERM), "size", List.of("1")))
+        .withHeaders(Map.of("Accept", "text/x-bibtex"))
+        .withRequestContext(getRequestContext())
+        .build();
+  }
+
+  private InputStream getBibtexInputStreamLargePageSize() throws JsonProcessingException {
+    return new HandlerRequestBuilder<Void>(objectMapperWithEmpty)
+        .withMultiValueQueryParameters(
+            Map.of(SEARCH_ALL.name(), List.of(SAMPLE_SEARCH_TERM), "size", List.of("100")))
+        .withHeaders(Map.of("Accept", "text/x-bibtex"))
+        .withRequestContext(getRequestContext())
+        .build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> rawHeaders(ByteArrayOutputStream outputStream)
+      throws IOException {
+    var typeRef = new TypeReference<Map<String, Object>>() {};
+    var response =
+        objectMapperWithEmpty.readValue(outputStream.toString(StandardCharsets.UTF_8), typeRef);
+    return (Map<String, String>) response.get("headers");
   }
 
   private InputStream getInputStream(String version) throws JsonProcessingException {

--- a/search-handlers/src/test/java/no/unit/nva/search/SearchResourceAuthHandlerTest.java
+++ b/search-handlers/src/test/java/no/unit/nva/search/SearchResourceAuthHandlerTest.java
@@ -9,6 +9,9 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static nva.commons.core.ioutils.IoUtils.stringFromResources;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,13 +22,16 @@ import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import no.unit.nva.constants.Words;
 import no.unit.nva.search.common.records.SwsResponse;
@@ -96,6 +102,23 @@ class SearchResourceAuthHandlerTest {
   }
 
   @Test
+  void shouldEmitPaginationHeadersWhenRequestingBibtex() throws IOException {
+    prepareRestHighLevelClientOkResponse();
+
+    handler.handleRequest(
+        getBibtexInputStreamWithAccessRight(
+            randomUri(), randomUri(), AccessRight.MANAGE_RESOURCES_ALL),
+        outputStream,
+        contextMock);
+
+    var headers = rawHeaders(outputStream);
+    assertThat(headers, hasEntry("X-Total-Count", "2"));
+    assertThat(headers, hasEntry("Access-Control-Expose-Headers", "Link, X-Total-Count"));
+    assertThat(headers, hasKey("Link"));
+    assertThat(headers.get("Link"), containsString("rel=\"first\""));
+  }
+
+  @Test
   void shouldReturnUnauthorizedWhenUserIsMissingAccessRight() throws IOException {
     prepareRestHighLevelClientOkResponse();
 
@@ -128,6 +151,29 @@ class SearchResourceAuthHandlerTest {
         .withAccessRights(currentCustomer, accessRight)
         .withHeaders(Map.of("Authorization", "Bearer " + randomString()))
         .build();
+  }
+
+  private InputStream getBibtexInputStreamWithAccessRight(
+      URI currentCustomer, URI topLevelCristinOrgId, AccessRight accessRight)
+      throws JsonProcessingException {
+    return new HandlerRequestBuilder<Void>(objectMapperWithEmpty)
+        .withMultiValueQueryParameters(Map.of("size", List.of("1")))
+        .withRequestContext(getRequestContext())
+        .withUserName(randomString())
+        .withCurrentCustomer(currentCustomer)
+        .withTopLevelCristinOrgId(topLevelCristinOrgId)
+        .withAccessRights(currentCustomer, accessRight)
+        .withHeaders(Map.of(ACCEPT, "text/x-bibtex", "Authorization", "Bearer " + randomString()))
+        .build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> rawHeaders(ByteArrayOutputStream outputStream)
+      throws IOException {
+    var typeRef = new TypeReference<Map<String, Object>>() {};
+    var response =
+        objectMapperWithEmpty.readValue(outputStream.toString(StandardCharsets.UTF_8), typeRef);
+    return (Map<String, String>) response.get("headers");
   }
 
   private ObjectNode getRequestContext() {

--- a/template.yaml
+++ b/template.yaml
@@ -24,7 +24,6 @@ Globals:
       AllowMethods: "'PUT, GET,OPTIONS,DELETE,POST'"
       AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
       AllowOrigin: "'*'"
-      ExposeHeaders: "'Link,X-Total-Count'"
 
 Parameters:
   CognitoUri:

--- a/template.yaml
+++ b/template.yaml
@@ -24,6 +24,7 @@ Globals:
       AllowMethods: "'PUT, GET,OPTIONS,DELETE,POST'"
       AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
       AllowOrigin: "'*'"
+      ExposeHeaders: "'Link,X-Total-Count'"
 
 Parameters:
   CognitoUri:


### PR DESCRIPTION
## Summary

Emit RFC 8288 `Link` header (rel=first/prev/next/last) and `X-Total-Count` on `text/x-bibtex` and `text/csv` responses so frontends can paginate plain-text exports that have no `nextResults` in the body.

- `HttpResponseFormatter.paginationHeaders()` builds `Link` + `X-Total-Count` based on `from`/`size`/total hits, only for CSV and bibtex media types
- Wired into `SearchResourceHandler`, `SearchResourceAuthHandler`, `SearchTicketAuthHandler`, and `SearchImportCandidateAuthHandler`
- `Link` is omitted when there is only a single page or no results
- `rel="prev"` / `rel="next"` are conditionally emitted based on current offset
- Lambda emits `Access-Control-Expose-Headers: Link, X-Total-Count` so browsers can read the new headers cross-origin
- New `Words.SIZE` constant alongside the existing `Words.FROM`

https://sikt.atlassian.net/browse/NP-51216