### PR TITLE
fix(search-commons): Slim _source for BibTeX to avoid 413 from SWS

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/resource/Constants.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/Constants.java
@@ -106,6 +106,17 @@ public final class Constants {
   public static final String CRISTIN_ORGANIZATION_PATH = "/cristin/organization/";
   public static final String CRISTIN_PERSON_PATH = "/cristin/person/";
   public static final List<String> GLOBAL_EXCLUDED_FIELDS = List.of("joinField");
+  public static final List<String> BIBTEX_INCLUDED_FIELDS =
+      List.of(
+          ID,
+          HANDLE,
+          DOI,
+          jsonPath(ENTITY_DESCRIPTION, ABSTRACT),
+          jsonPath(ENTITY_DESCRIPTION, MAIN_TITLE),
+          jsonPath(ENTITY_DESCRIPTION, PUBLICATION_DATE),
+          jsonPath(ENTITY_DESCRIPTION, TAGS),
+          jsonPath(ENTITY_DESCRIPTION, CONTRIBUTORS, IDENTITY, NAME),
+          jsonPath(ENTITY_DESCRIPTION, REFERENCE));
   public static final String IDENTIFIER_KEYWORD = jsonPath(IDENTIFIER, KEYWORD);
   public static final String FILES_STATUS_KEYWORD = jsonPath(FILES_STATUS, KEYWORD);
   public static final String ENTITY_CONTRIBUTORS = jsonPath(ENTITY_DESCRIPTION, CONTRIBUTORS);

--- a/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSearchQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSearchQuery.java
@@ -1,6 +1,8 @@
 package no.unit.nva.search.resource;
 
 import static java.lang.String.format;
+import static java.util.Objects.nonNull;
+import static no.unit.nva.constants.Defaults.BIBTEX_UTF_8;
 import static no.unit.nva.constants.Words.COMMA;
 import static no.unit.nva.constants.Words.CRISTIN_AS_TYPE;
 import static no.unit.nva.constants.Words.HTTPS;
@@ -8,6 +10,7 @@ import static no.unit.nva.constants.Words.IDENTIFIER;
 import static no.unit.nva.constants.Words.PI;
 import static no.unit.nva.constants.Words.SCOPUS_AS_TYPE;
 import static no.unit.nva.constants.Words.STATUS;
+import static no.unit.nva.search.resource.Constants.BIBTEX_INCLUDED_FIELDS;
 import static no.unit.nva.search.resource.Constants.CRISTIN_ORGANIZATION_PATH;
 import static no.unit.nva.search.resource.Constants.CRISTIN_PERSON_PATH;
 import static no.unit.nva.search.resource.Constants.GLOBAL_EXCLUDED_FIELDS;
@@ -133,7 +136,13 @@ public final class ResourceSearchQuery extends SearchQuery<ResourceParameter> {
 
   @Override
   protected String[] include() {
-    return getIncludedFields().toArray(String[]::new);
+    return isBibtexMediaType()
+        ? BIBTEX_INCLUDED_FIELDS.toArray(String[]::new)
+        : getIncludedFields().toArray(String[]::new);
+  }
+
+  private boolean isBibtexMediaType() {
+    return nonNull(getMediaType()) && BIBTEX_UTF_8.matches(getMediaType());
   }
 
   @Override

--- a/search-commons/src/test/java/no/unit/nva/search/resource/ResourceSearchQueryTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/resource/ResourceSearchQueryTest.java
@@ -22,6 +22,7 @@ import static no.unit.nva.search.resource.ResourceParameter.SIZE;
 import static no.unit.nva.search.resource.ResourceParameter.SORT;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -256,6 +257,33 @@ class ResourceSearchQueryTest {
                 .withRequiredParameters(FROM, SIZE)
                 .build()
                 .openSearchUri(Words.RESOURCES));
+  }
+
+  @Test
+  void shouldSlimSourceToBibtexFieldsWhenMediaTypeIsBibtex() throws BadRequestException {
+    var query =
+        ResourceSearchQuery.builder()
+            .fromTestQueryParameters(queryToMapEntries(URI.create("https://example.com/?size=3")))
+            .withRequiredParameters(FROM, SIZE)
+            .withMediaType(Words.TEXT_X_BIBTEX)
+            .build();
+
+    var body = query.assemble(Words.RESOURCES).findFirst().orElseThrow().body();
+
+    assertTrue(body.contains("entityDescription.contributors.identity.name"));
+  }
+
+  @Test
+  void shouldNotSlimSourceForDefaultMediaType() throws BadRequestException {
+    var query =
+        ResourceSearchQuery.builder()
+            .fromTestQueryParameters(queryToMapEntries(URI.create("https://example.com/?size=3")))
+            .withRequiredParameters(FROM, SIZE)
+            .build();
+
+    var body = query.assemble(Words.RESOURCES).findFirst().orElseThrow().body();
+
+    assertFalse(body.contains("entityDescription.contributors.identity.name"));
   }
 
   @Test


### PR DESCRIPTION
Resource searches requested as BibTeX (`Accept: text/x-bibtex`) could fail with a generic 500 that wrapped a 413 *Request Entity Too Large* from the Search Infrastructure (SWS). The cause was that `_source` returned the full contributor tree (identity, affiliations, roles, labels) for every hit, so publications with very many contributors exceeded the SWS response-size limit — even with small `size`.

This slims `_source` to only the fields the BibTeX transformer actually reads when the negotiated media type is BibTeX, pruning contributors down to `identity.name`. That keeps the response well under the SWS limit.

- Add `BIBTEX_INCLUDED_FIELDS` with the minimal BibTeX field set (contributors slimmed to `identity.name`)
- Override `ResourceSearchQuery.include()` to use the slim set for BibTeX, leaving all other media types unchanged
- Apply at the query layer, so it covers every resource search handler
- Add tests verifying `_source` is slimmed for BibTeX and untouched for the default media type

https://sikt.atlassian.net/browse/NP-51352