### PR TITLE
test(search-commons): Verify BibTeX source-slim completeness and extend slimming to CSV

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformer.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformer.java
@@ -1,5 +1,17 @@
 package no.unit.nva.search.common.bibtex;
 
+import static no.unit.nva.constants.Words.ABSTRACT;
+import static no.unit.nva.constants.Words.CONTRIBUTORS;
+import static no.unit.nva.constants.Words.DOI;
+import static no.unit.nva.constants.Words.ENTITY_DESCRIPTION;
+import static no.unit.nva.constants.Words.HANDLE;
+import static no.unit.nva.constants.Words.ID;
+import static no.unit.nva.constants.Words.IDENTITY;
+import static no.unit.nva.constants.Words.MAIN_TITLE;
+import static no.unit.nva.constants.Words.NAME;
+import static no.unit.nva.constants.Words.PUBLICATION_DATE;
+import static no.unit.nva.constants.Words.REFERENCE;
+import static no.unit.nva.constants.Words.TAGS;
 import static no.unit.nva.search.common.bibtex.BibtexConstants.ARTICLE;
 import static no.unit.nva.search.common.bibtex.BibtexConstants.BOOK;
 import static no.unit.nva.search.common.bibtex.BibtexConstants.INBOOK;
@@ -34,6 +46,7 @@ import static no.unit.nva.search.common.bibtex.BibtexFieldExtractors.pages;
 import static no.unit.nva.search.common.bibtex.BibtexFieldExtractors.pagesOrManifestationPages;
 import static no.unit.nva.search.common.bibtex.BibtexFieldExtractors.publisherOrManifestationPublisher;
 import static no.unit.nva.search.common.bibtex.BibtexFieldExtractors.text;
+import static no.unit.nva.search.common.constant.Functions.jsonPath;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
@@ -104,6 +117,19 @@ public final class ResourceBibTexTransformer {
     return hits.stream()
         .map(ResourceBibTexTransformer::toEntry)
         .collect(Collectors.joining(ENTRY_SEPARATOR));
+  }
+
+  public static List<String> getBibTexFields() {
+    return List.of(
+        ID,
+        HANDLE,
+        DOI,
+        jsonPath(ENTITY_DESCRIPTION, ABSTRACT),
+        jsonPath(ENTITY_DESCRIPTION, MAIN_TITLE),
+        jsonPath(ENTITY_DESCRIPTION, PUBLICATION_DATE),
+        jsonPath(ENTITY_DESCRIPTION, TAGS),
+        jsonPath(ENTITY_DESCRIPTION, CONTRIBUTORS, IDENTITY, NAME),
+        jsonPath(ENTITY_DESCRIPTION, REFERENCE));
   }
 
   private static String toEntry(JsonNode doc) {

--- a/search-commons/src/main/java/no/unit/nva/search/resource/Constants.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/Constants.java
@@ -106,17 +106,6 @@ public final class Constants {
   public static final String CRISTIN_ORGANIZATION_PATH = "/cristin/organization/";
   public static final String CRISTIN_PERSON_PATH = "/cristin/person/";
   public static final List<String> GLOBAL_EXCLUDED_FIELDS = List.of("joinField");
-  public static final List<String> BIBTEX_INCLUDED_FIELDS =
-      List.of(
-          ID,
-          HANDLE,
-          DOI,
-          jsonPath(ENTITY_DESCRIPTION, ABSTRACT),
-          jsonPath(ENTITY_DESCRIPTION, MAIN_TITLE),
-          jsonPath(ENTITY_DESCRIPTION, PUBLICATION_DATE),
-          jsonPath(ENTITY_DESCRIPTION, TAGS),
-          jsonPath(ENTITY_DESCRIPTION, CONTRIBUTORS, IDENTITY, NAME),
-          jsonPath(ENTITY_DESCRIPTION, REFERENCE));
   public static final String IDENTIFIER_KEYWORD = jsonPath(IDENTIFIER, KEYWORD);
   public static final String FILES_STATUS_KEYWORD = jsonPath(FILES_STATUS, KEYWORD);
   public static final String ENTITY_CONTRIBUTORS = jsonPath(ENTITY_DESCRIPTION, CONTRIBUTORS);

--- a/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSearchQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSearchQuery.java
@@ -1,8 +1,6 @@
 package no.unit.nva.search.resource;
 
 import static java.lang.String.format;
-import static java.util.Objects.nonNull;
-import static no.unit.nva.constants.Defaults.BIBTEX_UTF_8;
 import static no.unit.nva.constants.Words.COMMA;
 import static no.unit.nva.constants.Words.CRISTIN_AS_TYPE;
 import static no.unit.nva.constants.Words.HTTPS;
@@ -10,7 +8,6 @@ import static no.unit.nva.constants.Words.IDENTIFIER;
 import static no.unit.nva.constants.Words.PI;
 import static no.unit.nva.constants.Words.SCOPUS_AS_TYPE;
 import static no.unit.nva.constants.Words.STATUS;
-import static no.unit.nva.search.resource.Constants.BIBTEX_INCLUDED_FIELDS;
 import static no.unit.nva.search.resource.Constants.CRISTIN_ORGANIZATION_PATH;
 import static no.unit.nva.search.resource.Constants.CRISTIN_PERSON_PATH;
 import static no.unit.nva.search.resource.Constants.GLOBAL_EXCLUDED_FIELDS;
@@ -136,13 +133,7 @@ public final class ResourceSearchQuery extends SearchQuery<ResourceParameter> {
 
   @Override
   protected String[] include() {
-    return isBibtexMediaType()
-        ? BIBTEX_INCLUDED_FIELDS.toArray(String[]::new)
-        : getIncludedFields().toArray(String[]::new);
-  }
-
-  private boolean isBibtexMediaType() {
-    return nonNull(getMediaType()) && BIBTEX_UTF_8.matches(getMediaType());
+    return ResourceSourceFields.forMediaType(getMediaType(), getIncludedFields());
   }
 
   @Override

--- a/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSourceFields.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSourceFields.java
@@ -1,0 +1,39 @@
+package no.unit.nva.search.resource;
+
+import static java.util.Objects.nonNull;
+import static no.unit.nva.constants.Defaults.BIBTEX_UTF_8;
+import static no.unit.nva.search.resource.Constants.BIBTEX_INCLUDED_FIELDS;
+import static nva.commons.apigateway.MediaType.CSV_UTF_8;
+
+import java.util.Collection;
+import no.unit.nva.search.common.csv.ResourceCsvTransformer;
+import nva.commons.apigateway.MediaType;
+
+/**
+ * Resolves the OpenSearch {@code _source} include fields for a resource search.
+ *
+ * <p>BibTeX and CSV exports return many hits, and the full document (contributor affiliations,
+ * files, funding) can exceed the search infrastructure response-size limit. For those media types
+ * the source is slimmed to the fields the transformer actually reads. JSON requests are unaffected
+ * and keep their configured include set.
+ */
+final class ResourceSourceFields {
+
+  private ResourceSourceFields() {}
+
+  static String[] forMediaType(MediaType mediaType, Collection<String> defaultIncludedFields) {
+    final Collection<String> includedFields;
+    if (matches(mediaType, BIBTEX_UTF_8)) {
+      includedFields = BIBTEX_INCLUDED_FIELDS;
+    } else if (matches(mediaType, CSV_UTF_8)) {
+      includedFields = ResourceCsvTransformer.getJsonFields();
+    } else {
+      includedFields = defaultIncludedFields;
+    }
+    return includedFields.toArray(String[]::new);
+  }
+
+  private static boolean matches(MediaType actualMediaType, MediaType expectedMediaType) {
+    return nonNull(actualMediaType) && expectedMediaType.matches(actualMediaType);
+  }
+}

--- a/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSourceFields.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/ResourceSourceFields.java
@@ -2,10 +2,10 @@ package no.unit.nva.search.resource;
 
 import static java.util.Objects.nonNull;
 import static no.unit.nva.constants.Defaults.BIBTEX_UTF_8;
-import static no.unit.nva.search.resource.Constants.BIBTEX_INCLUDED_FIELDS;
 import static nva.commons.apigateway.MediaType.CSV_UTF_8;
 
 import java.util.Collection;
+import no.unit.nva.search.common.bibtex.ResourceBibTexTransformer;
 import no.unit.nva.search.common.csv.ResourceCsvTransformer;
 import nva.commons.apigateway.MediaType;
 
@@ -24,7 +24,7 @@ final class ResourceSourceFields {
   static String[] forMediaType(MediaType mediaType, Collection<String> defaultIncludedFields) {
     final Collection<String> includedFields;
     if (matches(mediaType, BIBTEX_UTF_8)) {
-      includedFields = BIBTEX_INCLUDED_FIELDS;
+      includedFields = ResourceBibTexTransformer.getBibTexFields();
     } else if (matches(mediaType, CSV_UTF_8)) {
       includedFields = ResourceCsvTransformer.getJsonFields();
     } else {

--- a/search-commons/src/test/java/no/unit/nva/search/common/bibtex/BibtexIncludedFieldsCompletenessTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/bibtex/BibtexIncludedFieldsCompletenessTest.java
@@ -1,0 +1,90 @@
+package no.unit.nva.search.common.bibtex;
+
+import static java.util.Objects.nonNull;
+import static no.unit.nva.search.resource.Constants.BIBTEX_INCLUDED_FIELDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Verifies that {@code Constants.BIBTEX_INCLUDED_FIELDS} (the OpenSearch {@code _source} include
+ * list used for BibTeX requests) covers every field the BibTeX transformation reads. The test
+ * emulates {@code _source} include filtering and asserts that the filtered documents produce the
+ * same BibTeX output as the full documents. If a future change reads a field outside the include
+ * list, the slimmed search response would silently drop it and this test fails.
+ */
+class BibtexIncludedFieldsCompletenessTest implements BibtexTransformerBase {
+
+  @ParameterizedTest(name = "should produce identical bibtex from source-filtered hits in {0}")
+  @ValueSource(
+      strings = {
+        "bibtex_real_data.json",
+        "bibtex_academic_article.json",
+        "bibtex_academic_monograph.json",
+        "bibtex_conference_lecture.json",
+        "bibtex_degree_master.json",
+        "bibtex_degree_phd.json",
+        "bibtex_report_research.json"
+      })
+  void shouldProduceIdenticalBibtexFromSourceFilteredDocuments(String resourceFile)
+      throws IOException {
+    var data = BibtexTransformerBase.loadAndTransform(Path.of(resourceFile));
+    var filteredHits =
+        data.hits().stream().map(hit -> filterSource(hit, BIBTEX_INCLUDED_FIELDS)).toList();
+
+    var filteredBibtex = ResourceBibTexTransformer.transform(filteredHits);
+
+    assertThat(filteredBibtex).isNotEmpty().isEqualTo(data.bibtex());
+  }
+
+  private static JsonNode filterSource(JsonNode document, Collection<String> includedPaths) {
+    var pathTree = new PathNode();
+    includedPaths.forEach(pathTree::add);
+    return filter(document, pathTree);
+  }
+
+  private static JsonNode filter(JsonNode node, PathNode pathTree) {
+    JsonNode result;
+    if (node.isArray()) {
+      var filteredArray = MAPPER.createArrayNode();
+      node.forEach(element -> filteredArray.add(filter(element, pathTree)));
+      result = filteredArray;
+    } else if (node.isObject()) {
+      var filteredObject = MAPPER.createObjectNode();
+      node.fields()
+          .forEachRemaining(
+              entry -> {
+                var child = pathTree.children.get(entry.getKey());
+                if (nonNull(child)) {
+                  if (child.children.isEmpty()) {
+                    filteredObject.set(entry.getKey(), entry.getValue());
+                  } else if (entry.getValue().isContainerNode()) {
+                    filteredObject.set(entry.getKey(), filter(entry.getValue(), child));
+                  }
+                }
+              });
+      result = filteredObject;
+    } else {
+      result = node;
+    }
+    return result;
+  }
+
+  private static final class PathNode {
+    private final Map<String, PathNode> children = new HashMap<>();
+
+    private void add(String dotPath) {
+      var currentNode = this;
+      for (var segment : dotPath.split("\\.")) {
+        currentNode = currentNode.children.computeIfAbsent(segment, key -> new PathNode());
+      }
+    }
+  }
+}

--- a/search-commons/src/test/java/no/unit/nva/search/common/bibtex/BibtexIncludedFieldsCompletenessTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/bibtex/BibtexIncludedFieldsCompletenessTest.java
@@ -1,10 +1,11 @@
 package no.unit.nva.search.common.bibtex;
 
 import static java.util.Objects.nonNull;
-import static no.unit.nva.search.resource.Constants.BIBTEX_INCLUDED_FIELDS;
+import static no.unit.nva.search.common.bibtex.ResourceBibTexTransformer.getBibTexFields;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -37,7 +38,7 @@ class BibtexIncludedFieldsCompletenessTest implements BibtexTransformerBase {
       throws IOException {
     var data = BibtexTransformerBase.loadAndTransform(Path.of(resourceFile));
     var filteredHits =
-        data.hits().stream().map(hit -> filterSource(hit, BIBTEX_INCLUDED_FIELDS)).toList();
+        data.hits().stream().map(hit -> filterSource(hit, getBibTexFields())).toList();
 
     var filteredBibtex = ResourceBibTexTransformer.transform(filteredHits);
 
@@ -53,28 +54,38 @@ class BibtexIncludedFieldsCompletenessTest implements BibtexTransformerBase {
   private static JsonNode filter(JsonNode node, PathNode pathTree) {
     JsonNode result;
     if (node.isArray()) {
-      var filteredArray = MAPPER.createArrayNode();
-      node.forEach(element -> filteredArray.add(filter(element, pathTree)));
-      result = filteredArray;
+      result = filterArray(node, pathTree);
     } else if (node.isObject()) {
-      var filteredObject = MAPPER.createObjectNode();
-      node.fields()
-          .forEachRemaining(
-              entry -> {
-                var child = pathTree.children.get(entry.getKey());
-                if (nonNull(child)) {
-                  if (child.children.isEmpty()) {
-                    filteredObject.set(entry.getKey(), entry.getValue());
-                  } else if (entry.getValue().isContainerNode()) {
-                    filteredObject.set(entry.getKey(), filter(entry.getValue(), child));
-                  }
-                }
-              });
-      result = filteredObject;
+      result = filterObject(node, pathTree);
     } else {
       result = node;
     }
     return result;
+  }
+
+  private static JsonNode filterArray(JsonNode node, PathNode pathTree) {
+    var filteredArray = MAPPER.createArrayNode();
+    node.forEach(element -> filteredArray.add(filter(element, pathTree)));
+    return filteredArray;
+  }
+
+  private static JsonNode filterObject(JsonNode node, PathNode pathTree) {
+    var filteredObject = MAPPER.createObjectNode();
+    node.fields().forEachRemaining(entry -> copyIncludedField(filteredObject, entry, pathTree));
+    return filteredObject;
+  }
+
+  private static void copyIncludedField(
+      ObjectNode target, Map.Entry<String, JsonNode> entry, PathNode pathTree) {
+    var child = pathTree.children.get(entry.getKey());
+    var isLeafInclude = nonNull(child) && child.children.isEmpty();
+    var isRecursiveInclude =
+        nonNull(child) && !child.children.isEmpty() && entry.getValue().isContainerNode();
+    if (isLeafInclude) {
+      target.set(entry.getKey(), entry.getValue());
+    } else if (isRecursiveInclude) {
+      target.set(entry.getKey(), filter(entry.getValue(), child));
+    }
   }
 
   private static final class PathNode {

--- a/search-commons/src/test/java/no/unit/nva/search/resource/ResourceSearchQueryTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/resource/ResourceSearchQueryTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.constants.Words;
+import no.unit.nva.search.common.csv.ResourceCsvTransformer;
 import no.unit.nva.search.common.records.PagedSearch;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.paths.UriWrapper;
@@ -271,6 +272,20 @@ class ResourceSearchQueryTest {
     var body = query.assemble(Words.RESOURCES).findFirst().orElseThrow().body();
 
     assertTrue(body.contains("entityDescription.contributors.identity.name"));
+  }
+
+  @Test
+  void shouldSlimSourceToCsvFieldsWhenMediaTypeIsCsv() throws BadRequestException {
+    var query =
+        ResourceSearchQuery.builder()
+            .fromTestQueryParameters(queryToMapEntries(URI.create("https://example.com/?size=3")))
+            .withRequiredParameters(FROM, SIZE)
+            .withMediaType(Words.TEXT_CSV)
+            .build();
+
+    var body = query.assemble(Words.RESOURCES).findFirst().orElseThrow().body();
+
+    ResourceCsvTransformer.getJsonFields().forEach(field -> assertTrue(body.contains(field)));
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #801 (now merged), which slimmed the OpenSearch `_source` for BibTeX exports to avoid a 413 from the search infrastructure (SWS). This adds the two pieces left on the table.

## What this adds

### 1. Completeness test for the BibTeX include list
`BibtexIncludedFieldsCompletenessTest` prunes each BibTeX real-data fixture down to `Constants.BIBTEX_INCLUDED_FIELDS` (emulating OpenSearch `_source` include filtering) and asserts the transformer produces byte-identical output to the full document, across all 7 fixtures.

Why: the field list is hand-maintained. If someone later makes the transformer read a field that is not in the list, the slimmed search response silently drops it and exports lose data with no test failure. This test fails loudly in that case.

### 2. Extend slimming to CSV
The inline CSV path on the search endpoints (`Accept: text/csv` on `/search/resources`) has the same unbounded `_source` problem BibTeX did. `ResourceSearchQuery.include()` never read `NODES_INCLUDED`, so the `NODES_INCLUDED` that `ExportResourceHandler` sets is actually inert for resources; the bulk CSV export only avoids 413 via its page-size-halving retry loop. Inline CSV has no such backstop.

This resolves the include set by media type, reusing `ResourceCsvTransformer.getJsonFields()` as the single source of truth for CSV fields (the same list the CSV export already intends to use).

### 3. Small refactor: `ResourceSourceFields`
The media-type-to-include-fields decision is extracted into a tiny helper. Adding the CSV branch inline tipped the PMD GodClass check on `ResourceSearchQuery` (an extra foreign-data access to `ResourceCsvTransformer`); moving the decision out keeps the query class under the threshold and makes the logic directly testable.

## Verification
- `./gradlew build` green (PMD, Checkstyle, JaCoCo coverage, dependency analysis).
- New query-layer test asserts CSV media type yields the CSV field set in the assembled OpenSearch request; #801's existing tests already cover BibTeX and the untouched default path.

## Note on tickets
This work and #801 both address the same SWS 413 on BibTeX export, tracked separately as NP-51328 (this) and NP-51352 (#801). They are duplicates; NP-51328 should be closed or linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)