### PR TITLE
fix(bibtex): Use contributorsPreview to bound BibTeX response size

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/common/bibtex/BibtexFieldExtractors.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/bibtex/BibtexFieldExtractors.java
@@ -18,6 +18,8 @@ public final class BibtexFieldExtractors {
   static final String MONTH_POINTER = "/entityDescription/publicationDate/month";
   static final String TAGS_POINTER = "/entityDescription/tags";
   static final String CONTRIBUTORS_POINTER = "/entityDescription/contributors";
+  static final String CONTRIBUTORS_PREVIEW_POINTER = "/entityDescription/contributorsPreview";
+  static final String CONTRIBUTORS_COUNT_POINTER = "/entityDescription/contributorsCount";
   static final String IDENTITY_NAME_POINTER = "/identity/name";
   static final String DOI_POINTER = "/entityDescription/reference/doi";
   static final String NVA_DOI_POINTER = "/doi";
@@ -57,6 +59,7 @@ public final class BibtexFieldExtractors {
       "/entityDescription/reference/publicationInstance/manifestations";
 
   private static final String AND = " and ";
+  private static final String OTHERS = "others";
   private static final String INTERVAL = "--";
   private static final String EN_DASH = "–";
   private static final String DOI_URI_HOST_REGEX = "(?i)https?://doi\\.org/";
@@ -76,21 +79,34 @@ public final class BibtexFieldExtractors {
 
   public static BibtexFieldExtractor authors() {
     return doc -> {
-      var contributors = doc.at(CONTRIBUTORS_POINTER);
+      var contributors = contributorsNode(doc);
       if (contributors.isMissingNode() || !contributors.isArray()) {
         return Optional.empty();
       }
-      return StreamSupport.stream(contributors.spliterator(), false)
-          .flatMap(contributor -> extractText(contributor, IDENTITY_NAME_POINTER).stream())
-          .filter(not(String::isBlank))
-          .collect(
-              Collectors.collectingAndThen(
-                  Collectors.joining(AND),
-                  names ->
-                      names.isEmpty()
-                          ? Optional.empty()
-                          : Optional.of(new BibtexField("author", names))));
+      var names =
+          StreamSupport.stream(contributors.spliterator(), false)
+              .flatMap(contributor -> extractText(contributor, IDENTITY_NAME_POINTER).stream())
+              .filter(not(String::isBlank))
+              .toList();
+      if (names.isEmpty()) {
+        return Optional.empty();
+      }
+      var joinedNames = String.join(AND, names);
+      if (hasMoreContributorsThan(doc, contributors.size())) {
+        joinedNames = String.join(AND, joinedNames, OTHERS);
+      }
+      return Optional.of(new BibtexField("author", joinedNames));
     };
+  }
+
+  private static JsonNode contributorsNode(JsonNode doc) {
+    var preview = doc.at(CONTRIBUTORS_PREVIEW_POINTER);
+    return preview.isMissingNode() ? doc.at(CONTRIBUTORS_POINTER) : preview;
+  }
+
+  private static boolean hasMoreContributorsThan(JsonNode doc, int shownContributors) {
+    var contributorsCount = doc.at(CONTRIBUTORS_COUNT_POINTER);
+    return contributorsCount.isInt() && contributorsCount.asInt() > shownContributors;
   }
 
   public static BibtexFieldExtractor doi() {

--- a/search-commons/src/main/java/no/unit/nva/search/resource/Constants.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/Constants.java
@@ -115,7 +115,8 @@ public final class Constants {
           jsonPath(ENTITY_DESCRIPTION, MAIN_TITLE),
           jsonPath(ENTITY_DESCRIPTION, PUBLICATION_DATE),
           jsonPath(ENTITY_DESCRIPTION, TAGS),
-          jsonPath(ENTITY_DESCRIPTION, CONTRIBUTORS, IDENTITY, NAME),
+          jsonPath(ENTITY_DESCRIPTION, CONTRIBUTORS_PREVIEW, IDENTITY, NAME),
+          jsonPath(ENTITY_DESCRIPTION, CONTRIBUTORS_COUNT),
           jsonPath(ENTITY_DESCRIPTION, REFERENCE));
   public static final String IDENTIFIER_KEYWORD = jsonPath(IDENTIFIER, KEYWORD);
   public static final String FILES_STATUS_KEYWORD = jsonPath(FILES_STATUS, KEYWORD);

--- a/search-commons/src/test/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformerTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformerTest.java
@@ -235,6 +235,36 @@ class ResourceBibTexTransformerTest {
   }
 
   @Test
+  void shouldReadAuthorsFromContributorsPreview() {
+    var doc = docWithInstanceType("AcademicArticle");
+    setContributors(doc, "Full Only");
+    setContributorsPreview(doc, "Preview One", "Preview Two");
+    setContributorsCount(doc, 2);
+    var result = ResourceBibTexTransformer.transform(List.of(doc));
+    assertThat(result, containsString("  author = {Preview One and Preview Two}"));
+    assertThat(result, not(containsString("Full Only")));
+  }
+
+  @Test
+  void shouldAppendAndOthersWhenContributorsAreTruncated() {
+    var doc = docWithInstanceType("AcademicArticle");
+    setContributorsPreview(doc, "Alice Aaberg", "Bob Bakke");
+    setContributorsCount(doc, 3000);
+    var result = ResourceBibTexTransformer.transform(List.of(doc));
+    assertThat(result, containsString("  author = {Alice Aaberg and Bob Bakke and others}"));
+  }
+
+  @Test
+  void shouldNotAppendAndOthersWhenPreviewContainsAllContributors() {
+    var doc = docWithInstanceType("AcademicArticle");
+    setContributorsPreview(doc, "Alice Aaberg", "Bob Bakke");
+    setContributorsCount(doc, 2);
+    var result = ResourceBibTexTransformer.transform(List.of(doc));
+    assertThat(result, containsString("  author = {Alice Aaberg and Bob Bakke}"));
+    assertThat(result, not(containsString("others")));
+  }
+
+  @Test
   void shouldStripDoiResolverPrefix() {
     var doc = docWithInstanceType("AcademicArticle");
     setDoi(doc, "https://doi.org/10.1234/test");
@@ -672,6 +702,17 @@ class ResourceBibTexTransformerTest {
       var c = contributors.addObject();
       c.putObject("identity").put("name", name);
     }
+  }
+
+  private static void setContributorsPreview(ObjectNode doc, String... names) {
+    var preview = ((ObjectNode) doc.path("entityDescription")).putArray("contributorsPreview");
+    for (var name : names) {
+      preview.addObject().putObject("identity").put("name", name);
+    }
+  }
+
+  private static void setContributorsCount(ObjectNode doc, int count) {
+    ((ObjectNode) doc.path("entityDescription")).put("contributorsCount", count);
   }
 
   private static void setDoi(ObjectNode doc, String doi) {

--- a/search-commons/src/test/java/no/unit/nva/search/resource/ResourceSearchQueryTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/resource/ResourceSearchQueryTest.java
@@ -270,7 +270,8 @@ class ResourceSearchQueryTest {
 
     var body = query.assemble(Words.RESOURCES).findFirst().orElseThrow().body();
 
-    assertTrue(body.contains("entityDescription.contributors.identity.name"));
+    assertTrue(body.contains("entityDescription.contributorsPreview.identity.name"));
+    assertTrue(body.contains("entityDescription.contributorsCount"));
   }
 
   @Test
@@ -283,7 +284,7 @@ class ResourceSearchQueryTest {
 
     var body = query.assemble(Words.RESOURCES).findFirst().orElseThrow().body();
 
-    assertFalse(body.contains("entityDescription.contributors.identity.name"));
+    assertFalse(body.contains("entityDescription.contributorsPreview.identity.name"));
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #801. Slimming `_source` to contributor names was not enough for UiO publications with thousands of contributors (large international collaborations) — a page of 100 such records still exceeds the ~5-6MB SWS response limit and returns 413→500.

This switches the BibTeX path to read the upstream-truncated `entityDescription.contributorsPreview` instead of the full `contributors` array, which bounds the per-document size regardless of how many contributors a publication has.

- Fetch `contributorsPreview.identity.name` + `contributorsCount` in `_source` instead of the full `contributors`
- Read authors from `contributorsPreview` (fallback to `contributors` when preview is absent on older documents)
- Append `and others` when `contributorsCount` exceeds the number of shown contributors
- Decision stays in the query layer (`ResourceSearchQuery.include()`), so all resource search handlers are covered
- Add tests for truncation/`and others`, preview preference, and the slimmed `_source` paths

**Open risk (why this is a draft):** this only bounds the response if `contributorsPreview` is actually truncated to a small number upstream. All test fixtures are small publications (preview == full list), so this could not be verified here for a mega-author paper. The same failing UiO call should be re-tested after deploy, or the preview cap confirmed in the publication/resource service.

https://sikt.atlassian.net/browse/NP-51352