### PR TITLE
feat(search-commons): Add nva_api field to BibTeX export

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformer.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformer.java
@@ -117,6 +117,9 @@ public final class ResourceBibTexTransformer {
     if (!url.isBlank()) {
       fields.add(new BibtexField("url", url));
     }
+    if (!id.isBlank()) {
+      fields.add(new BibtexField("nva_api", id));
+    }
     Stream.concat(
             UNIVERSAL_EXTRACTORS.stream(),
             TYPE_EXTRACTORS.getOrDefault(bibType, List.of()).stream())

--- a/search-commons/src/test/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformerTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformerTest.java
@@ -294,6 +294,24 @@ class ResourceBibTexTransformerTest {
   }
 
   @Test
+  void shouldIncludeNvaApiFieldFromId() {
+    var doc = docWithInstanceType("AcademicArticle");
+    setPath(doc, "id", "https://api.nva.unit.no/publication/abc-123");
+    var result = ResourceBibTexTransformer.transform(List.of(doc));
+    assertThat(result, containsString("  nva_api = {https://api.nva.unit.no/publication/abc-123}"));
+  }
+
+  @Test
+  void shouldIncludeBothUrlAndNvaApiWhenHandlePresent() {
+    var doc = docWithInstanceType("AcademicArticle");
+    setPath(doc, "id", "https://api.nva.unit.no/publication/abc-123");
+    setPath(doc, "handle", "https://hdl.handle.net/11250/9999999");
+    var result = ResourceBibTexTransformer.transform(List.of(doc));
+    assertThat(result, containsString("  url = {https://hdl.handle.net/11250/9999999}"));
+    assertThat(result, containsString("  nva_api = {https://api.nva.unit.no/publication/abc-123}"));
+  }
+
+  @Test
   void shouldExtractAbstract() {
     var doc = docWithInstanceType("AcademicArticle");
     ((com.fasterxml.jackson.databind.node.ObjectNode) doc.path("entityDescription"))


### PR DESCRIPTION
Add an `nva_api` field to BibTeX entries pointing to the NVA API publication URI.

- Emit `nva_api = {<id>}` from the resource `/id` in `ResourceBibTexTransformer`
- Complements `url` (which prefers `handle`), so consumers always get a stable NVA API pointer even when a handle is present
- `id` is already in `BIBTEX_INCLUDED_FIELDS`, so no query/`_source` change needed
- Add tests covering the new field with and without a handle

https://sikt.atlassian.net/browse/NP-51230