### PR TITLE
fix(search-commons): Output full DOI URI in BibTeX export

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/common/bibtex/BibtexFieldExtractors.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/bibtex/BibtexFieldExtractors.java
@@ -59,7 +59,6 @@ public final class BibtexFieldExtractors {
   private static final String AND = " and ";
   private static final String INTERVAL = "--";
   private static final String EN_DASH = "–";
-  private static final String DOI_URI_HOST_REGEX = "(?i)https?://doi\\.org/";
   private static final String CONTEXT_TYPE_UNCONFIRMED_JOURNAL = "UnconfirmedJournal";
   private static final String CONTEXT_TYPE_ANTHOLOGY = "Anthology";
   private static final String LITERARY_ARTS_MONOGRAPH_TYPE = "LiteraryArtsMonograph";
@@ -97,7 +96,7 @@ public final class BibtexFieldExtractors {
     return doc ->
         extractText(doc, DOI_POINTER)
             .or(() -> extractText(doc, NVA_DOI_POINTER))
-            .map(doi -> doi.replaceFirst(DOI_URI_HOST_REGEX, EMPTY_STRING).strip())
+            .map(String::strip)
             .filter(not(String::isBlank))
             .map(doi -> new BibtexField("doi", doi));
   }

--- a/search-commons/src/test/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformerArticleRealDataTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformerArticleRealDataTest.java
@@ -61,8 +61,8 @@ class ResourceBibTexTransformerArticleRealDataTest implements BibtexTransformerB
   }
 
   @Test
-  void shouldStripDoiPrefix() {
-    assertThat(bibtex, containsString("  doi = {10.54648/eulr2025047}"));
+  void shouldIncludeFullDoiUri() {
+    assertThat(bibtex, containsString("  doi = {https://doi.org/10.54648/eulr2025047}"));
   }
 
   @Test

--- a/search-commons/src/test/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformerRealDataTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformerRealDataTest.java
@@ -65,7 +65,7 @@ class ResourceBibTexTransformerRealDataTest implements BibtexTransformerBase {
 
   @Test
   void shouldExtractDoiWhenPresent() {
-    assertThat(bibtex, containsString("  doi = {10.4337/9781035313877.00016}"));
+    assertThat(bibtex, containsString("  doi = {https://doi.org/10.4337/9781035313877.00016}"));
   }
 
   @Test

--- a/search-commons/src/test/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformerTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/bibtex/ResourceBibTexTransformerTest.java
@@ -235,19 +235,11 @@ class ResourceBibTexTransformerTest {
   }
 
   @Test
-  void shouldStripDoiResolverPrefix() {
+  void shouldIncludeFullDoiUri() {
     var doc = docWithInstanceType("AcademicArticle");
     setDoi(doc, "https://doi.org/10.1234/test");
     var result = ResourceBibTexTransformer.transform(List.of(doc));
-    assertThat(result, containsString("  doi = {10.1234/test}"));
-  }
-
-  @Test
-  void shouldStripHttpDoiResolverPrefix() {
-    var doc = docWithInstanceType("AcademicArticle");
-    setDoi(doc, "http://doi.org/10.1234/test");
-    var result = ResourceBibTexTransformer.transform(List.of(doc));
-    assertThat(result, containsString("  doi = {10.1234/test}"));
+    assertThat(result, containsString("  doi = {https://doi.org/10.1234/test}"));
   }
 
   @Test
@@ -330,7 +322,7 @@ class ResourceBibTexTransformerTest {
     doc.putObject("entityDescription").putObject("reference");
     setPath(doc, "doi", "https://doi.org/10.1234/fallback");
     var result = ResourceBibTexTransformer.transform(List.of(doc));
-    assertThat(result, containsString("  doi = {10.1234/fallback}"));
+    assertThat(result, containsString("  doi = {https://doi.org/10.1234/fallback}"));
   }
 
   @Test


### PR DESCRIPTION
Emit the full `https://doi.org/` URI in the BibTeX/biblatex `doi` field instead of stripping the resolver prefix down to a bare identifier.

- `doi()` now passes the DOI value through unchanged — the source already stores the full URI, so the field renders as `doi = {https://doi.org/10.1016/...}`
- Removed the now-unused resolver-prefix stripping and its constants

Note: non-DOI URLs occasionally stored in the `doi` field (e.g. YouTube/handle links) are out of scope here and tracked separately.

https://sikt.atlassian.net/browse/NP-51297
