### PR TITLE
feat(search-commons): Paginate CSV/BibTeX exports with search_after past 10k

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
@@ -165,22 +165,25 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
   }
 
   private Optional<URI> nextPageUri() {
-    if (!hasFullPage()) {
-      return Optional.empty();
-    }
-    var sortValues = sortValuesOfLastHit();
-    if (!hasContent(sortValues)) {
-      return Optional.empty();
-    }
+    return doesNotHaveFullPage() || doesNotHaveSortValues()
+        ? Optional.empty()
+        : Optional.of(generateNextPageUri());
+  }
+
+  private URI generateNextPageUri() {
     var params = getRequestParameter();
     params.remove(Words.FROM);
     params.put(Words.SIZE, String.valueOf(size));
-    params.put(searchAfterParameterName(), sortValues);
-    return Optional.of(fromUri(source).addQueryParameters(params).getUri());
+    params.put(searchAfterParameterName(), sortValuesOfLastHit());
+    return fromUri(source).addQueryParameters(params).getUri();
   }
 
-  private boolean hasFullPage() {
-    return response.getSearchHits().size() >= size;
+  private boolean doesNotHaveFullPage() {
+    return response.getSearchHits().size() < size;
+  }
+
+  private boolean doesNotHaveSortValues() {
+    return !hasContent(sortValuesOfLastHit());
   }
 
   private String sortValuesOfLastHit() {

--- a/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/records/HttpResponseFormatter.java
@@ -39,9 +39,8 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
   private static final String EXPOSED_PAGINATION_HEADERS =
       String.join(", ", HEADER_LINK, HEADER_X_TOTAL_COUNT);
   private static final String REL_FIRST = "first";
-  private static final String REL_PREV = "prev";
   private static final String REL_NEXT = "next";
-  private static final String REL_LAST = "last";
+  private static final String NULL_SORT_VALUE = "null";
   private static final String LINK_VALUE_FORMAT = "<%s>; rel=\"%s\"";
   private static final String LINK_HEADER_SEPARATOR = ", ";
 
@@ -147,16 +146,9 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
     if (!isPaginatable(total)) {
       return Optional.empty();
     }
-    var current = nonNull(offset) ? offset : 0;
     var links = new ArrayList<String>();
-    links.add(formatLink(uriWithFrom(0), REL_FIRST));
-    if (current > 0) {
-      links.add(formatLink(uriWithFrom(Math.max(0, current - size)), REL_PREV));
-    }
-    if (current + size < total) {
-      links.add(formatLink(uriWithFrom(current + size), REL_NEXT));
-    }
-    links.add(formatLink(uriWithFrom(lastPageOffset(total)), REL_LAST));
+    links.add(formatLink(firstPageUri(), REL_FIRST));
+    nextPageUri().ifPresent(uri -> links.add(formatLink(uri, REL_NEXT)));
     return Optional.of(String.join(LINK_HEADER_SEPARATOR, links));
   }
 
@@ -164,15 +156,41 @@ public final class HttpResponseFormatter<K extends Enum<K> & ParameterKey<K>> {
     return total > 0 && nonNull(size) && size > 0 && total > size;
   }
 
-  private int lastPageOffset(int total) {
-    return (total - 1) / size * size;
-  }
-
-  private URI uriWithFrom(int newFrom) {
+  private URI firstPageUri() {
     var params = getRequestParameter();
-    params.put(Words.FROM, String.valueOf(newFrom));
+    params.remove(Words.FROM);
+    params.remove(searchAfterParameterName());
     params.put(Words.SIZE, String.valueOf(size));
     return fromUri(source).addQueryParameters(params).getUri();
+  }
+
+  private Optional<URI> nextPageUri() {
+    if (!hasFullPage()) {
+      return Optional.empty();
+    }
+    var sortValues = sortValuesOfLastHit();
+    if (!hasContent(sortValues)) {
+      return Optional.empty();
+    }
+    var params = getRequestParameter();
+    params.remove(Words.FROM);
+    params.put(Words.SIZE, String.valueOf(size));
+    params.put(searchAfterParameterName(), sortValues);
+    return Optional.of(fromUri(source).addQueryParameters(params).getUri());
+  }
+
+  private boolean hasFullPage() {
+    return response.getSearchHits().size() >= size;
+  }
+
+  private String sortValuesOfLastHit() {
+    return response.getSort().stream()
+        .map(value -> nonNull(value) ? value : NULL_SORT_VALUE)
+        .collect(Collectors.joining(COMMA));
+  }
+
+  private static String searchAfterParameterName() {
+    return Words.SEARCH_AFTER.toLowerCase(Locale.getDefault());
   }
 
   private static String formatLink(URI uri, String rel) {

--- a/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
@@ -12,9 +12,9 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import no.unit.nva.search.common.records.SwsResponse.HitsInfo;
 import no.unit.nva.search.common.records.SwsResponse.HitsInfo.Hit;
 import no.unit.nva.search.common.records.SwsResponse.HitsInfo.TotalInfo;
@@ -183,14 +183,25 @@ class HttpResponseFormatterPaginationHeadersTest {
 
   private static HttpResponseFormatter<?> formatter(
       MediaType mediaType, int size, int totalHits, int hitsOnPage, List<String> lastHitSort) {
-    var hits = new ArrayList<Hit>();
-    for (int index = 0; index < hitsOnPage; index++) {
-      var isLastHit = index == hitsOnPage - 1;
-      hits.add(searchHitCarryingSortValues(isLastHit ? lastHitSort : null));
-    }
+    var hits = hitsWithCursorOnLastHit(hitsOnPage, lastHitSort);
     var hitsInfo = new HitsInfo(new TotalInfo(totalHits, "eq"), 0.0, hits);
     var swsResponse = new SwsResponse(0, false, null, hitsInfo, null, null);
     return new HttpResponseFormatter<>(swsResponse, mediaType, SOURCE, 0, size, Map.of(), null);
+  }
+
+  private static List<Hit> hitsWithCursorOnLastHit(int hitsOnPage, List<String> lastHitSort) {
+    if (hitsOnPage == 0) {
+      return List.of();
+    }
+    return Stream.concat(
+            Stream.generate(HttpResponseFormatterPaginationHeadersTest::searchHitWithoutSortValues)
+                .limit(hitsOnPage - 1L),
+            Stream.of(searchHitCarryingSortValues(lastHitSort)))
+        .toList();
+  }
+
+  private static Hit searchHitWithoutSortValues() {
+    return searchHitCarryingSortValues(null);
   }
 
   private static Hit searchHitCarryingSortValues(List<String> sortValues) {

--- a/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
@@ -12,9 +12,11 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import no.unit.nva.search.common.records.SwsResponse.HitsInfo;
+import no.unit.nva.search.common.records.SwsResponse.HitsInfo.Hit;
 import no.unit.nva.search.common.records.SwsResponse.HitsInfo.TotalInfo;
 import nva.commons.apigateway.MediaType;
 import nva.commons.apigateway.MediaTypes;
@@ -27,59 +29,60 @@ class HttpResponseFormatterPaginationHeadersTest {
   private static final String X_TOTAL_COUNT = "X-Total-Count";
   private static final String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
   private static final String EXPECTED_EXPOSED_HEADERS = "Link, X-Total-Count";
+  private static final List<String> LAST_HIT_SORT = List.of("2017", "abc-123");
 
   @Test
   void shouldReturnEmptyHeadersWhenMediaTypeIsJson() {
-    var headers = formatterFor(JSON_UTF_8, 0, 10, 100).paginationHeaders();
+    var headers = formatterFor(JSON_UTF_8, 10, 100, 10).paginationHeaders();
 
     assertThat(headers, anEmptyMap());
   }
 
   @Test
   void shouldReturnEmptyHeadersWhenMediaTypeIsJsonLd() {
-    var headers = formatterFor(MediaTypes.APPLICATION_JSON_LD, 0, 10, 100).paginationHeaders();
+    var headers = formatterFor(MediaTypes.APPLICATION_JSON_LD, 10, 100, 10).paginationHeaders();
 
     assertThat(headers, anEmptyMap());
   }
 
   @Test
   void shouldEmitExposeHeadersForCsv() {
-    var headers = formatterFor(CSV_UTF_8, 0, 10, 100).paginationHeaders();
+    var headers = formatterFor(CSV_UTF_8, 10, 100, 10).paginationHeaders();
 
     assertThat(headers, hasEntry(ACCESS_CONTROL_EXPOSE_HEADERS, EXPECTED_EXPOSED_HEADERS));
   }
 
   @Test
   void shouldEmitExposeHeadersForBibtex() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+    var headers = formatterFor(BIBTEX_UTF_8, 10, 100, 10).paginationHeaders();
 
     assertThat(headers, hasEntry(ACCESS_CONTROL_EXPOSE_HEADERS, EXPECTED_EXPOSED_HEADERS));
   }
 
   @Test
   void shouldEmitExposeHeadersEvenWhenSinglePage() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 100, 25).paginationHeaders();
+    var headers = formatterFor(BIBTEX_UTF_8, 100, 25, 25).paginationHeaders();
 
     assertThat(headers, hasEntry(ACCESS_CONTROL_EXPOSE_HEADERS, EXPECTED_EXPOSED_HEADERS));
   }
 
   @Test
   void shouldEmitTotalCountHeaderForCsv() {
-    var headers = formatterFor(CSV_UTF_8, 0, 10, 100).paginationHeaders();
+    var headers = formatterFor(CSV_UTF_8, 10, 100, 10).paginationHeaders();
 
     assertThat(headers, hasEntry(X_TOTAL_COUNT, "100"));
   }
 
   @Test
   void shouldEmitTotalCountHeaderForBibtex() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+    var headers = formatterFor(BIBTEX_UTF_8, 10, 100, 10).paginationHeaders();
 
     assertThat(headers, hasEntry(X_TOTAL_COUNT, "100"));
   }
 
   @Test
-  void shouldEmitFirstNextAndLastButNotPrevOnFirstPage() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+  void shouldEmitFirstAndNextButNotPrevOrLastWhenMoreResultsExist() {
+    var headers = formatterFor(BIBTEX_UTF_8, 10, 100, 10).paginationHeaders();
 
     var link = headers.get(LINK);
     assertThat(
@@ -87,69 +90,43 @@ class HttpResponseFormatterPaginationHeadersTest {
         allOf(
             containsString("rel=\"first\""),
             containsString("rel=\"next\""),
-            containsString("rel=\"last\""),
-            not(containsString("rel=\"prev\""))));
+            not(containsString("rel=\"prev\"")),
+            not(containsString("rel=\"last\""))));
   }
 
   @Test
-  void shouldEmitAllRelsOnMiddlePage() {
-    var headers = formatterFor(BIBTEX_UTF_8, 20, 10, 100).paginationHeaders();
+  void shouldEmitFirstButNotNextOnLastPage() {
+    var headers = formatterFor(BIBTEX_UTF_8, 10, 100, 4).paginationHeaders();
 
     var link = headers.get(LINK);
-    assertThat(
-        link,
-        allOf(
-            containsString("rel=\"first\""),
-            containsString("rel=\"prev\""),
-            containsString("rel=\"next\""),
-            containsString("rel=\"last\"")));
+    assertThat(link, allOf(containsString("rel=\"first\""), not(containsString("rel=\"next\""))));
   }
 
   @Test
-  void shouldEmitFirstPrevAndLastButNotNextOnLastPage() {
-    var headers = formatterFor(BIBTEX_UTF_8, 90, 10, 100).paginationHeaders();
+  void shouldPointNextAtSearchAfterCursor() {
+    var headers = formatterFor(BIBTEX_UTF_8, 10, 100, 10).paginationHeaders();
+
+    assertThat(headers.get(LINK), containsString("search_after="));
+  }
+
+  @Test
+  void shouldNotUseOffsetForLinks() {
+    var headers = formatterFor(BIBTEX_UTF_8, 10, 100, 10).paginationHeaders();
+
+    assertThat(headers.get(LINK), not(containsString("from=")));
+  }
+
+  @Test
+  void shouldOmitNextWhenLastHitHasNoSortValues() {
+    var headers = formatterWithoutSort(BIBTEX_UTF_8, 10, 100, 10).paginationHeaders();
 
     var link = headers.get(LINK);
-    assertThat(
-        link,
-        allOf(
-            containsString("rel=\"first\""),
-            containsString("rel=\"prev\""),
-            containsString("rel=\"last\""),
-            not(containsString("rel=\"next\""))));
-  }
-
-  @Test
-  void shouldPointLastAtFinalPageOffset() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 95).paginationHeaders();
-
-    assertThat(headers.get(LINK), containsString("from=90&size=10>; rel=\"last\""));
-  }
-
-  @Test
-  void shouldPointPrevAtPreviousPageOffset() {
-    var headers = formatterFor(BIBTEX_UTF_8, 30, 10, 100).paginationHeaders();
-
-    assertThat(headers.get(LINK), containsString("from=20&size=10>; rel=\"prev\""));
-  }
-
-  @Test
-  void shouldPointNextAtNextPageOffset() {
-    var headers = formatterFor(BIBTEX_UTF_8, 30, 10, 100).paginationHeaders();
-
-    assertThat(headers.get(LINK), containsString("from=40&size=10>; rel=\"next\""));
-  }
-
-  @Test
-  void shouldClampPrevAtZeroWhenOffsetSmallerThanSize() {
-    var headers = formatterFor(BIBTEX_UTF_8, 5, 10, 100).paginationHeaders();
-
-    assertThat(headers.get(LINK), containsString("from=0&size=10>; rel=\"prev\""));
+    assertThat(link, allOf(containsString("rel=\"first\""), not(containsString("rel=\"next\""))));
   }
 
   @Test
   void shouldOmitLinkHeaderWhenSinglePage() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 100, 25).paginationHeaders();
+    var headers = formatterFor(BIBTEX_UTF_8, 100, 25, 25).paginationHeaders();
 
     assertThat(headers, hasEntry(X_TOTAL_COUNT, "25"));
     assertThat(headers, not(hasKey(LINK)));
@@ -157,7 +134,7 @@ class HttpResponseFormatterPaginationHeadersTest {
 
   @Test
   void shouldOmitLinkHeaderWhenTotalIsZero() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 0).paginationHeaders();
+    var headers = formatterFor(BIBTEX_UTF_8, 10, 0, 0).paginationHeaders();
 
     assertThat(headers, hasEntry(X_TOTAL_COUNT, "0"));
     assertThat(headers, not(hasKey(LINK)));
@@ -165,7 +142,7 @@ class HttpResponseFormatterPaginationHeadersTest {
 
   @Test
   void shouldOmitLinkHeaderWhenSizeIsZero() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 0, 100).paginationHeaders();
+    var headers = formatterFor(BIBTEX_UTF_8, 0, 100, 0).paginationHeaders();
 
     assertThat(headers, hasEntry(X_TOTAL_COUNT, "100"));
     assertThat(headers, not(hasKey(LINK)));
@@ -173,21 +150,21 @@ class HttpResponseFormatterPaginationHeadersTest {
 
   @Test
   void shouldUseSourceUriAsBaseForLinks() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+    var headers = formatterFor(BIBTEX_UTF_8, 10, 100, 10).paginationHeaders();
 
     assertThat(headers.get(LINK), containsString(SOURCE.toString()));
   }
 
   @Test
   void shouldIncludeSizeInLinkUrls() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+    var headers = formatterFor(BIBTEX_UTF_8, 10, 100, 10).paginationHeaders();
 
     assertThat(headers.get(LINK), containsString("size=10"));
   }
 
   @Test
   void shouldFormatLinkValueWithRfc8288Syntax() {
-    var headers = formatterFor(BIBTEX_UTF_8, 0, 10, 100).paginationHeaders();
+    var headers = formatterFor(BIBTEX_UTF_8, 10, 100, 10).paginationHeaders();
     var link = headers.get(LINK);
 
     assertThat(link, containsString("<"));
@@ -195,10 +172,24 @@ class HttpResponseFormatterPaginationHeadersTest {
   }
 
   private static HttpResponseFormatter<?> formatterFor(
-      MediaType mediaType, int offset, int size, int totalHits) {
-    var hitsInfo = new HitsInfo(new TotalInfo(totalHits, "eq"), 0.0, List.of());
+      MediaType mediaType, int size, int totalHits, int hitsOnPage) {
+    return formatter(mediaType, size, totalHits, hitsOnPage, LAST_HIT_SORT);
+  }
+
+  private static HttpResponseFormatter<?> formatterWithoutSort(
+      MediaType mediaType, int size, int totalHits, int hitsOnPage) {
+    return formatter(mediaType, size, totalHits, hitsOnPage, List.of());
+  }
+
+  private static HttpResponseFormatter<?> formatter(
+      MediaType mediaType, int size, int totalHits, int hitsOnPage, List<String> lastHitSort) {
+    var hits = new ArrayList<Hit>();
+    for (int index = 0; index < hitsOnPage; index++) {
+      var sort = index == hitsOnPage - 1 ? lastHitSort : null;
+      hits.add(new Hit(null, null, null, 0.0, null, null, sort));
+    }
+    var hitsInfo = new HitsInfo(new TotalInfo(totalHits, "eq"), 0.0, hits);
     var swsResponse = new SwsResponse(0, false, null, hitsInfo, null, null);
-    return new HttpResponseFormatter<>(
-        swsResponse, mediaType, SOURCE, offset, size, Map.of(), null);
+    return new HttpResponseFormatter<>(swsResponse, mediaType, SOURCE, 0, size, Map.of(), null);
   }
 }

--- a/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/records/HttpResponseFormatterPaginationHeadersTest.java
@@ -185,11 +185,15 @@ class HttpResponseFormatterPaginationHeadersTest {
       MediaType mediaType, int size, int totalHits, int hitsOnPage, List<String> lastHitSort) {
     var hits = new ArrayList<Hit>();
     for (int index = 0; index < hitsOnPage; index++) {
-      var sort = index == hitsOnPage - 1 ? lastHitSort : null;
-      hits.add(new Hit(null, null, null, 0.0, null, null, sort));
+      var isLastHit = index == hitsOnPage - 1;
+      hits.add(searchHitCarryingSortValues(isLastHit ? lastHitSort : null));
     }
     var hitsInfo = new HitsInfo(new TotalInfo(totalHits, "eq"), 0.0, hits);
     var swsResponse = new SwsResponse(0, false, null, hitsInfo, null, null);
     return new HttpResponseFormatter<>(swsResponse, mediaType, SOURCE, 0, size, Map.of(), null);
+  }
+
+  private static Hit searchHitCarryingSortValues(List<String> sortValues) {
+    return new Hit(null, null, null, 0.0, null, null, sortValues);
   }
 }

--- a/search-handlers/src/test/java/no/unit/nva/search/SearchResource20241201HandlerTest.java
+++ b/search-handlers/src/test/java/no/unit/nva/search/SearchResource20241201HandlerTest.java
@@ -113,7 +113,9 @@ class SearchResource20241201HandlerTest {
     assertThat(headers, hasKey("Link"));
     assertThat(headers.get("Link"), containsString("rel=\"first\""));
     assertThat(headers.get("Link"), containsString("rel=\"next\""));
-    assertThat(headers.get("Link"), containsString("rel=\"last\""));
+    assertThat(headers.get("Link"), containsString("search_after="));
+    assertThat(headers.get("Link"), not(containsString("rel=\"last\"")));
+    assertThat(headers.get("Link"), not(containsString("rel=\"prev\"")));
   }
 
   @Test

--- a/search-handlers/src/test/resources/sample_opensearch_response.json
+++ b/search-handlers/src/test/resources/sample_opensearch_response.json
@@ -53,7 +53,8 @@
             "name": "Organization"
           },
           "abstract": "abstract of the publication"
-        }
+        },
+        "sort": ["2017", "f367b260-c15e-4d0f-b197-e1dc0e9eb0e8"]
       },
       {
         "_index": "resources",
@@ -94,7 +95,8 @@
             "name": "Organization"
           },
           "abstract": "abstract of the publication"
-        }
+        },
+        "sort": ["2017", "aea76470-39af-4943-b876-061f7576baa5"]
       }
     ]
   },


### PR DESCRIPTION
Replaces offset-based pagination with a forward `search_after` cursor for CSV and BibTeX responses on `/search/resources`, so clients can page beyond the 10k offset limit. The JSON endpoint and its pagination are left untouched.

- Build the plain-text `Link` header with `rel="first"` + `rel="next"`, where `next` is a `search_after` cursor (the last hit's sort values)
- Omit `rel="next"` once the last page is reached (non-full page, or no sort values)
- Drop `rel="prev"`/`rel="last"` for CSV/BibTeX — not expressible with a forward cursor
- Remove the now-unused offset helpers (`uriWithFrom`, `lastPageOffset`, `REL_PREV`/`REL_LAST`)
- Add `sort` arrays to the shared OpenSearch sample fixture so handler tests exercise the cursor