### PR TITLE
fix(indexing-handlers): Skip missing index on delete instead of failing

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/indexingclient/IndexingClient.java
+++ b/search-commons/src/main/java/no/unit/nva/indexingclient/IndexingClient.java
@@ -24,6 +24,7 @@ import no.unit.nva.search.common.jwt.CognitoAuthenticator;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Try;
 import nva.commons.secrets.SecretsReader;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.refresh.RefreshRequest;
 import org.opensearch.action.bulk.BulkRequest;
@@ -35,6 +36,7 @@ import org.opensearch.client.indices.GetMappingsRequest;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
@@ -49,6 +51,8 @@ public class IndexingClient extends AuthenticatedOpenSearchClientWrapper {
   private static final String INITIAL_LOG_MESSAGE = "Adding document [{}] to -> {}";
   private static final String DOCUMENT_WITH_ID_WAS_NOT_FOUND_IN_SEARCH_INFRASTRUCTURE =
       "Document with id={} was not found in search infrastructure";
+  private static final String INDEX_NOT_FOUND_NOTHING_TO_DELETE_MESSAGE =
+      "Index '{}' does not exist, nothing to delete";
   private static final boolean SEQUENTIAL = false;
 
   /**
@@ -149,7 +153,15 @@ public class IndexingClient extends AuthenticatedOpenSearchClientWrapper {
   }
 
   public Void deleteIndex(String indexName) throws IOException {
-    openSearchClient.indices().delete(new DeleteIndexRequest(indexName), getRequestOptions());
+    try {
+      openSearchClient.indices().delete(new DeleteIndexRequest(indexName), getRequestOptions());
+    } catch (OpenSearchStatusException exception) {
+      if (RestStatus.NOT_FOUND == exception.status()) {
+        logger.info(INDEX_NOT_FOUND_NOTHING_TO_DELETE_MESSAGE, indexName);
+      } else {
+        throw exception;
+      }
+    }
     return null;
   }
 

--- a/search-commons/src/test/java/no/unit/nva/indexingclient/IndexingClientTest.java
+++ b/search-commons/src/test/java/no/unit/nva/indexingclient/IndexingClientTest.java
@@ -44,6 +44,7 @@ import nva.commons.secrets.SecretsReader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.refresh.RefreshRequest;
@@ -55,6 +56,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.client.IndicesClient;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.indices.CreateIndexRequest;
+import org.opensearch.core.rest.RestStatus;
 
 class IndexingClientTest {
 
@@ -187,6 +189,18 @@ class IndexingClientTest {
     var expectedNumberOfCreateInvocationsToEs = 1;
     verify(indicesClient, times(expectedNumberOfCreateInvocationsToEs))
         .delete(any(DeleteIndexRequest.class), any(RequestOptions.class));
+  }
+
+  @Test
+  void shouldNotThrowWhenDeletingIndexThatDoesNotExist() throws IOException {
+    var indicesClient = mock(IndicesClient.class);
+    var indicesClientWrapper = new IndicesClientWrapper(indicesClient);
+    when(esClient.indices()).thenReturn(indicesClientWrapper);
+    when(indicesClient.delete(any(DeleteIndexRequest.class), any(RequestOptions.class)))
+        .thenThrow(
+            new OpenSearchStatusException("no such index [some-index]", RestStatus.NOT_FOUND));
+
+    assertDoesNotThrow(() -> indexingClient.deleteIndex(randomString()));
   }
 
   @Test


### PR DESCRIPTION
Makes index deletion tolerant of missing indices so a single missing index no longer aborts the whole delete job.

- `DeleteIndicesHandler` previously aborted on the first missing index because OpenSearch throws `OpenSearchStatusException` (a `RuntimeException`), which the handler loop only caught as `IOException`.
- `IndexingClient.deleteIndex` is now idempotent: a `NOT_FOUND` (404) status is logged as info and treated as a no-op; any other status is re-thrown.
- The handler loop now continues to the next index when one is missing.
- Added a regression test reproducing the crash.

https://sikt.atlassian.net/browse/NP-51394