### PR TITLE
fix(search): content-negotiate media type and limit ticket/import-candidate to JSON

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/constants/Defaults.java
+++ b/search-commons/src/main/java/no/unit/nva/constants/Defaults.java
@@ -30,13 +30,6 @@ public final class Defaults {
 
   public static final MediaType BIBTEX_UTF_8 = MediaType.parse("text/x-bibtex; charset=utf-8");
 
-  public static final List<MediaType> DEFAULT_RESPONSE_MEDIA_TYPES =
-      List.of(
-          MediaType.JSON_UTF_8,
-          MediaTypes.APPLICATION_JSON_LD,
-          MediaTypes.SCHEMA_ORG,
-          MediaType.CSV_UTF_8);
-
   public static final List<MediaType> RESOURCE_RESPONSE_MEDIA_TYPES =
       List.of(
           MediaType.JSON_UTF_8,

--- a/search-commons/src/main/java/no/unit/nva/constants/Words.java
+++ b/search-commons/src/main/java/no/unit/nva/constants/Words.java
@@ -138,7 +138,6 @@ public final class Words {
   public static final String STATUS = "status";
   public static final String SUFFIX = ")";
   public static final String TAGS = "tags";
-  public static final String APPLICATION_LD_JSON = "application/ld+json";
   public static final String TEXT_CSV = "text/csv";
   public static final String TEXT_X_BIBTEX = "text/x-bibtex";
   public static final String TICKETS = "tickets";

--- a/search-commons/src/main/java/no/unit/nva/search/common/SearchQuery.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/SearchQuery.java
@@ -1,5 +1,6 @@
 package no.unit.nva.search.common;
 
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.constants.Defaults.BIBTEX_UTF_8;
 import static no.unit.nva.constants.Defaults.DEFAULT_SORT_ORDER;
@@ -23,11 +24,13 @@ import static nva.commons.core.attempt.Try.attempt;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -78,6 +81,10 @@ import org.slf4j.LoggerFactory;
 public abstract class SearchQuery<K extends Enum<K> & ParameterKey<K>> extends Query<K> {
 
   protected static final Logger logger = LoggerFactory.getLogger(SearchQuery.class);
+  private static final String LD_JSON_ESSENCE = "application/ld+json";
+  private static final String SCHEMA_ORG_ESSENCE = "application/vnd.schemaorg.ld+json";
+  private static final String JSON_ESSENCE = "application/json";
+  private static final URI SCHEMA_ORG_PROFILE = URI.create("https://schema.org");
   private final transient Set<AccessRight> accessRights;
   private transient MediaType mediaType;
   private transient Set<String> excludedFields = Set.of();
@@ -207,30 +214,29 @@ public abstract class SearchQuery<K extends Enum<K> & ParameterKey<K>> extends Q
   }
 
   final void setMediaType(String mediaType) {
-    if (mediaType == null) {
+    if (isNull(mediaType)) {
       this.mediaType = JSON_UTF_8;
       return;
     }
-    var parsed = MediaTypeParser.defaultParser().parse(mediaType).first();
-    if (parsed.isEmpty()) {
-      this.mediaType = JSON_UTF_8;
-      return;
-    }
-    var mt = parsed.get();
-    var essence = mt.essence();
-    if (essence.contains("vnd.schemaorg.ld+json")
-        || (essence.contains("ld+json")
-            && mt.profiles().contains(URI.create("https://schema.org")))) {
-      this.mediaType = SCHEMA_ORG;
-    } else if (essence.contains("ld+json")) {
-      this.mediaType = APPLICATION_JSON_LD;
-    } else if (essence.contains(Words.TEXT_CSV)) {
-      this.mediaType = CSV_UTF_8;
-    } else if (essence.contains(TEXT_X_BIBTEX)) {
-      this.mediaType = BIBTEX_UTF_8;
-    } else {
-      this.mediaType = JSON_UTF_8;
-    }
+    this.mediaType =
+        MediaTypeParser.defaultParser().parseList(mediaType).preferenceOrder().stream()
+            .flatMap(
+                requested ->
+                    toResponseMediaType(requested.essence(), requested.profiles()).stream())
+            .findFirst()
+            .orElse(JSON_UTF_8);
+  }
+
+  private static Optional<MediaType> toResponseMediaType(String essence, Collection<URI> profiles) {
+    return switch (essence) {
+      case SCHEMA_ORG_ESSENCE -> Optional.of(SCHEMA_ORG);
+      case LD_JSON_ESSENCE ->
+          Optional.of(profiles.contains(SCHEMA_ORG_PROFILE) ? SCHEMA_ORG : APPLICATION_JSON_LD);
+      case Words.TEXT_CSV -> Optional.of(CSV_UTF_8);
+      case TEXT_X_BIBTEX -> Optional.of(BIBTEX_UTF_8);
+      case JSON_ESSENCE -> Optional.of(JSON_UTF_8);
+      default -> Optional.empty();
+    };
   }
 
   public URI getNvaSearchApiUri() {

--- a/search-commons/src/test/java/no/unit/nva/search/resource/ResourceSearchQueryTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/resource/ResourceSearchQueryTest.java
@@ -43,6 +43,7 @@ import java.util.stream.Stream;
 import no.unit.nva.constants.Words;
 import no.unit.nva.search.common.csv.ResourceCsvTransformer;
 import no.unit.nva.search.common.records.PagedSearch;
+import nva.commons.apigateway.MediaTypes;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.paths.UriWrapper;
 import org.joda.time.DateTime;
@@ -299,6 +300,35 @@ class ResourceSearchQueryTest {
     var body = query.assemble(Words.RESOURCES).findFirst().orElseThrow().body();
 
     assertFalse(body.contains("entityDescription.contributors.identity.name"));
+  }
+
+  @ParameterizedTest(name = "should resolve media type SCHEMA_ORG for accept header {0}")
+  @ValueSource(
+      strings = {
+        "application/vnd.schemaorg.ld+json",
+        "application/ld+json; profile=\"https://schema.org\""
+      })
+  void shouldResolveSchemaOrgMediaType(String acceptHeader) throws BadRequestException {
+    var query =
+        ResourceSearchQuery.builder()
+            .fromTestQueryParameters(queryToMapEntries(URI.create("https://example.com/?size=3")))
+            .withRequiredParameters(FROM, SIZE)
+            .withMediaType(acceptHeader)
+            .build();
+
+    assertEquals(MediaTypes.SCHEMA_ORG, query.getMediaType());
+  }
+
+  @Test
+  void shouldResolveApplicationJsonLdForPlainLdJsonAcceptHeader() throws BadRequestException {
+    var query =
+        ResourceSearchQuery.builder()
+            .fromTestQueryParameters(queryToMapEntries(URI.create("https://example.com/?size=3")))
+            .withRequiredParameters(FROM, SIZE)
+            .withMediaType("application/ld+json")
+            .build();
+
+    assertEquals(MediaTypes.APPLICATION_JSON_LD, query.getMediaType());
   }
 
   @Test

--- a/search-handlers/src/main/java/no/unit/nva/search/SearchImportCandidateAuthHandler.java
+++ b/search-handlers/src/main/java/no/unit/nva/search/SearchImportCandidateAuthHandler.java
@@ -1,6 +1,5 @@
 package no.unit.nva.search;
 
-import static no.unit.nva.constants.Defaults.DEFAULT_RESPONSE_MEDIA_TYPES;
 import static no.unit.nva.search.importcandidate.ImportCandidateClient.defaultClient;
 import static no.unit.nva.search.importcandidate.ImportCandidateParameter.AGGREGATION;
 import static no.unit.nva.search.importcandidate.ImportCandidateParameter.FROM;
@@ -64,7 +63,7 @@ public class SearchImportCandidateAuthHandler extends ApiGatewayHandler<Void, St
 
   @Override
   protected List<MediaType> listSupportedMediaTypes() {
-    return DEFAULT_RESPONSE_MEDIA_TYPES;
+    return List.of(MediaType.JSON_UTF_8);
   }
 
   @Override

--- a/search-handlers/src/main/java/no/unit/nva/search/SearchTicketAuthHandler.java
+++ b/search-handlers/src/main/java/no/unit/nva/search/SearchTicketAuthHandler.java
@@ -1,6 +1,5 @@
 package no.unit.nva.search;
 
-import static no.unit.nva.constants.Defaults.DEFAULT_RESPONSE_MEDIA_TYPES;
 import static no.unit.nva.search.ticket.TicketClient.defaultClient;
 import static no.unit.nva.search.ticket.TicketParameter.AGGREGATION;
 import static no.unit.nva.search.ticket.TicketParameter.FROM;
@@ -42,7 +41,7 @@ public class SearchTicketAuthHandler extends ApiGatewayHandler<Void, String> {
 
   @Override
   protected List<MediaType> listSupportedMediaTypes() {
-    return DEFAULT_RESPONSE_MEDIA_TYPES;
+    return List.of(MediaType.JSON_UTF_8);
   }
 
   @Override


### PR DESCRIPTION
Adresserer review-kommentarer på #809.

- `SearchQuery.setMediaType` bruker nå `MediaTypeParser.parseList` + `preferenceOrder`, slik at Accept-headere med flere media-typer (f.eks. `text/csv, application/json`) blir respektert i stedet for å falle tilbake til JSON. Dispatchen er en `switch` på eksakt `essence()`.
- Ticket- og import-candidate-endepunktene støtter nå kun `application/json`. ld+json/schema.org/csv gir 406 i stedet for tomme dokumenter — disse endepunktene mangler `entityDescription`, og CSV-transformeren leser kun publication-formede felter.
- Fjernet den delte `DEFAULT_RESPONSE_MEDIA_TYPES`; hvert endepunkt deklarerer nå sine egne støttede media-typer.
- Bruker `Objects.isNull` og fjernet ubrukt `APPLICATION_LD_JSON`-konstant.

ListItem-med-position for schema.org-outputen tas som egen PR.

https://sikt.atlassian.net/browse/NP-51371
