### PR TITLE
feat(search-commons): wrap schema.org itemListElement entries in ListItem with position

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/common/bibliography/SchemaOrgBibliographyTransformer.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/bibliography/SchemaOrgBibliographyTransformer.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.IntStream;
 import no.unit.nva.commons.json.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,8 @@ public final class SchemaOrgBibliographyTransformer {
   private static final ObjectMapper MAPPER = JsonUtils.dtoObjectMapper;
   private static final String SCHEMA_ORG_CONTEXT = "https://schema.org";
   private static final String ITEM_LIST_TYPE = "ItemList";
+  private static final String LIST_ITEM_TYPE = "ListItem";
+  private static final int FIRST_POSITION = 1;
 
   private SchemaOrgBibliographyTransformer() {} // NO-OP
 
@@ -46,7 +49,7 @@ public final class SchemaOrgBibliographyTransformer {
   }
 
   public static String transform(Collection<JsonNode> hits, int totalSize) {
-    var items = hits.stream().map(SchemaOrgItemTransformer::transform).toList();
+    var items = toListItems(hits);
     var itemList = new SchemaOrgItemList(SCHEMA_ORG_CONTEXT, ITEM_LIST_TYPE, totalSize, items);
     return attempt(() -> MAPPER.writeValueAsString(itemList))
         .orElseThrow(
@@ -54,5 +57,17 @@ public final class SchemaOrgBibliographyTransformer {
               LOGGER.error("Failed to serialize schema.org ItemList", failure.getException());
               return new RuntimeException(failure.getException());
             });
+  }
+
+  private static List<SchemaOrgListItem> toListItems(Collection<JsonNode> hits) {
+    var orderedHits = List.copyOf(hits);
+    return IntStream.range(0, orderedHits.size())
+        .mapToObj(index -> toListItem(index, orderedHits.get(index)))
+        .toList();
+  }
+
+  private static SchemaOrgListItem toListItem(int index, JsonNode hit) {
+    return new SchemaOrgListItem(
+        LIST_ITEM_TYPE, index + FIRST_POSITION, SchemaOrgItemTransformer.transform(hit));
   }
 }

--- a/search-commons/src/main/java/no/unit/nva/search/common/bibliography/SchemaOrgItemList.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/bibliography/SchemaOrgItemList.java
@@ -7,4 +7,4 @@ record SchemaOrgItemList(
     @JsonProperty("@context") String context,
     @JsonProperty("@type") String type,
     int numberOfItems,
-    List<SchemaOrgItem> itemListElement) {}
+    List<SchemaOrgListItem> itemListElement) {}

--- a/search-commons/src/main/java/no/unit/nva/search/common/bibliography/SchemaOrgListItem.java
+++ b/search-commons/src/main/java/no/unit/nva/search/common/bibliography/SchemaOrgListItem.java
@@ -1,0 +1,5 @@
+package no.unit.nva.search.common.bibliography;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+record SchemaOrgListItem(@JsonProperty("@type") String type, int position, SchemaOrgItem item) {}

--- a/search-commons/src/test/java/no/unit/nva/search/common/bibliography/SchemaOrgBibliographyTransformerTest.java
+++ b/search-commons/src/test/java/no/unit/nva/search/common/bibliography/SchemaOrgBibliographyTransformerTest.java
@@ -49,6 +49,26 @@ class SchemaOrgBibliographyTransformerTest {
     assertThat(tree.path("itemListElement").isEmpty()).isTrue();
   }
 
+  @Test
+  void shouldWrapEachItemInListItem() {
+    var doc = doc("AcademicArticle");
+    var listItem = parse(SchemaOrgBibliographyTransformer.transform(List.of(doc), 1))
+        .path("itemListElement")
+        .get(0);
+    assertThat(listItem.path("@type").asText()).isEqualTo("ListItem");
+    assertThat(listItem.path("item").path("@type").asText()).isEqualTo("ScholarlyArticle");
+  }
+
+  @Test
+  void shouldAssignOneBasedPositionToEachListItem() {
+    var doc = doc("AcademicArticle");
+    var elements =
+        parse(SchemaOrgBibliographyTransformer.transform(List.of(doc, doc), 2))
+            .path("itemListElement");
+    assertThat(elements.get(0).path("position").asInt()).isEqualTo(1);
+    assertThat(elements.get(1).path("position").asInt()).isEqualTo(2);
+  }
+
   static Stream<Arguments> typeMapping() {
     return Stream.of(
         Arguments.of("AcademicArticle", "ScholarlyArticle"),
@@ -662,7 +682,7 @@ class SchemaOrgBibliographyTransformerTest {
   }
 
   private static JsonNode item(JsonNode tree) {
-    return tree.path("itemListElement").get(0);
+    return tree.path("itemListElement").get(0).path("item");
   }
 
   private static JsonNode findInChain(JsonNode node, String type) {


### PR DESCRIPTION
Følger opp review-kommentaren på #809 om at `itemListElement` i en `ItemList` bør være en ordnet liste.

- Hvert hit wrappes nå i en `ListItem` med `@type` = `ListItem`, `position` og `item`, i tråd med schema.org for en ordnet `ItemList`.
- `position` er 1-basert innenfor den returnerte siden (transformeren har ikke offset, så paginering starter neste side på `position: 1`).
- Ny record `SchemaOrgListItem`; `SchemaOrgItemList.itemListElement` er nå `List<SchemaOrgListItem>`.
- Oppdaterte schema.org-testene til å navigere inn i `item` og la til tester for `ListItem`-type og posisjon.

Resulterende struktur:

```json
{
  "@context": "https://schema.org",
  "@type": "ItemList",
  "numberOfItems": 42,
  "itemListElement": [
    {
      "@type": "ListItem",
      "position": 1,
      "item": { "@type": "ScholarlyArticle", "@id": "…", "name": "…" }
    }
  ]
}
```

https://sikt.atlassian.net/browse/NP-51371
