### PR TITLE
fix(template): Allow Accept header in CORS for schema.org JSON-LD

### DIFF
--- a/search-commons/src/main/java/no/unit/nva/search/resource/SimplifiedMutator.java
+++ b/search-commons/src/main/java/no/unit/nva/search/resource/SimplifiedMutator.java
@@ -198,7 +198,6 @@ public class SimplifiedMutator implements JsonNodeMutator {
     return path.isMissingNode() ? Collections.emptyMap() : jsonNodeMapToMap(path);
   }
 
-
   private Map<String, String> jsonNodeMapToMap(JsonNode source) {
     return objectMapper.convertValue(source, new TypeReference<>() {});
   }

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Globals:
   Api:
     Cors:
       AllowMethods: "'PUT, GET,OPTIONS,DELETE,POST'"
-      AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+      AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Accept'"
       AllowOrigin: "'*'"
 
 Parameters:


### PR DESCRIPTION
Adds `Accept` to the API Gateway CORS `AllowHeaders` so browsers can request the schema.org JSON-LD format via the standardized profile syntax.

- Requesting `application/ld+json; profile="https://schema.org"` produces an `Accept` value containing CORS-unsafe bytes (`"` and `:`), which makes the browser send a preflight `OPTIONS` request
- The preflight lists `accept` in `Access-Control-Request-Headers`, but `Accept` was missing from `AllowHeaders`, so the browser blocked the request with a CORS error before it reached the Lambda
- Adding `Accept` to `AllowHeaders` lets the preflight succeed
- The `application/vnd.schemaorg.ld+json` variant already worked, since it contains no CORS-unsafe bytes and never triggers a preflight

https://sikt.atlassian.net/browse/NP-51371
